### PR TITLE
Add GitHub webhook receipt, cache invalidation, and live dashboard updates (#93)

### DIFF
--- a/.claude/plans/issue-93-github-webhooks.md
+++ b/.claude/plans/issue-93-github-webhooks.md
@@ -1,0 +1,217 @@
+# GitHub Webhook Support — Wrangler CI Issue #93
+
+## Context
+
+Wrangler currently polls the GitHub REST API every 2 minutes (workflow runs, pull requests) to keep the dashboard fresh. This burns API rate-limit budget and adds up to 2 minutes of UI latency after any change. Issue #93 asks for webhook delivery so the app can react to changes immediately and only re-fetch what actually changed.
+
+**User-confirmed direction:**
+- The GitHub registration on github.com is already a **GitHub App** (client ID `Iv23liIR4LMmkRTEwtiN`; `CallbackHandler.cs:28-30` already detects `installation_id`).
+- Frontend updates via **SSE push** in real time (the `@hey-api/openapi-ts` generator already scaffolds an SSE client at `src/api/core/serverSentEvents.gen.ts`, currently unused).
+- MVP events: `workflow_run`, `pull_request`, `check_run`, `check_suite`.
+
+Plan is split into four phases so each can ship independently as its own PR.
+
+---
+
+## Phase 1 — Receive & verify webhooks (no UX changes)
+
+Deployable baseline: webhooks arrive, signature is verified, deliveries are deduped, but caches stay TTL-driven.
+
+**Packages** (modify `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Wrangler.Api.csproj`):
+- `Octokit.Webhooks.AspNetCore` — typed event processor + minimal-API mapping with built-in HMAC verification.
+- `GitHubJwt` — only needed once we call GitHub as the App. Defer to Phase 4.
+
+**Configuration** (binds via `IOptions<GitHubAppOptions>` — new POCO at `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Models\GitHubAppOptions.cs`):
+
+| Key                          | Dev source     | Prod source             |
+|------------------------------|----------------|-------------------------|
+| `GitHubApp:AppId`            | user-secrets   | App Service config      |
+| `GitHubApp:ClientId`         | appsettings    | App Service config      |
+| `GitHubApp:WebhookSecret`    | user-secrets   | KeyVault                |
+| `GitHubApp:PrivateKeyPem`    | user-secrets   | KeyVault (Phase 4 only) |
+
+**New files:**
+- `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Models\GitHubAppOptions.cs`
+- `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Webhooks\GitHubWebhookEventProcessor.cs` — derives from `Octokit.Webhooks.WebhookEventProcessor`. Overrides:
+  `ProcessWorkflowRunWebhookAsync`, `ProcessPullRequestWebhookAsync`,
+  `ProcessCheckRunWebhookAsync`, `ProcessCheckSuiteWebhookAsync`,
+  `ProcessInstallationWebhookAsync`, `ProcessInstallationRepositoriesWebhookAsync`.
+  Phase 1: log + idempotency-dedupe only.
+- `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Services\IInstallationRegistry.cs` + `InstallationRegistry.cs` — Redis-backed.
+
+**Installation registry — Redis key shape** (no TTL):
+- `gh:install:{installationId}` → hash `{ account, accountId, type, suspendedAt? }`
+- `gh:install:{installationId}:repos` → set of `"<owner>/<repo>"`
+- `gh:repo:{owner}/{repo}:install` → string `installationId` (reverse lookup, used by Phase 2/3)
+
+**Idempotency:** `gh:delivery:{X-GitHub-Delivery}` → 1 byte, 10-min TTL. Processor checks-and-sets before doing work.
+
+**Modify `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Program.cs`:**
+- Register `WebhookEventProcessor` as singleton.
+- Bind `GitHubAppOptions`.
+- Call `app.MapGitHubWebhooks("/webhooks/github", options.WebhookSecret)` **outside** the `/api` group, with `.AllowAnonymous().ExcludeFromDescription()`.
+
+**Operational setup:**
+- Configure the GitHub App's webhook URL to `https://githubactionsdashboard.azurewebsites.net/webhooks/github`.
+- For local dev, document `smee.io` or `ngrok` and a `GitHubApp:WebhookUrl` user-secret override in the README.
+
+**Granular tasks:**
+1. Add packages + `GitHubAppOptions` binding.
+2. `InstallationRegistry` + tests (Redis hash/set ops).
+3. `GitHubWebhookEventProcessor` with idempotency only.
+4. Wire `MapGitHubWebhooks` in `Program.cs`.
+5. Configure App webhook URL; confirm 200s via App → Advanced → Recent Deliveries.
+6. Implement installation-lifecycle handlers (created / deleted / suspend / `installation_repositories` added / removed).
+7. Implement MVP event handlers as log-only.
+
+---
+
+## Phase 2 — Cache invalidation via per-repo data-version sidecar
+
+**Key challenge:** the Octokit response cache is keyed per-user (token-hash prefix from `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Services\CacheKeyService.cs`), but webhooks fire app-wide with no user context. We need invalidation that works without a user token.
+
+**Approach: data-version sidecar** (least invasive — no changes to per-user keying):
+- `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Services\IRepoVersionService.cs` + `RepoVersionService.cs` (new) — Redis `INCR` per `(owner, repo, kind)`:
+  - Key: `gh:ver:{owner}/{repo}:{kind}`, where `kind ∈ { workflows, workflow_runs, pulls, checks }`.
+  - `GetVersion(...)` returns the current counter (0 if absent).
+  - `Bump(...)` does `INCR`.
+- Modify `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Services\DistributedResponseCache.cs` (`GetCacheKey` at line 70): derive `(owner, repo, kind)` from `request.Endpoint`, look up the current version, append `:v{n}` to the key. Both `GetAsync` and `SetAsync` use this same builder, so versioning is symmetric. Endpoints that don't map (e.g., `/user/repos`) get no suffix and behave as today.
+- Endpoint → kind mapping (table-driven, unit-tested in isolation):
+  - `/repos/{o}/{r}/actions/workflows` → `workflows`
+  - `/repos/{o}/{r}/actions/workflows/{id}/runs` or `/repos/{o}/{r}/actions/runs` → `workflow_runs`
+  - `/repos/{o}/{r}/pulls...` → `pulls`
+  - `/repos/{o}/{r}/check-runs...` and `/check-suites...` → `checks`
+
+**Event → bump map** (in `GitHubWebhookEventProcessor`):
+
+| Event                         | Bumps                          |
+|-------------------------------|--------------------------------|
+| `workflow_run`                | `workflow_runs`, `workflows`   |
+| `check_run` / `check_suite`   | `checks`, `workflow_runs`      |
+| `pull_request` (open/close/sync/reopen/edit/ready_for_review) | `pulls` |
+
+Ignore noisy `pull_request` actions: `labeled`, `unlabeled`, `assigned`, `review_requested` (none change check status surfaced in our UI).
+
+**Granular tasks:**
+1. `RepoVersionService` + tests.
+2. Endpoint-→-kind mapper (most error-prone bit; corpus of real `IRequest.Endpoint` values captured from a debug session).
+3. Plumb mapper into `DistributedResponseCache.GetCacheKey`.
+4. Wire `Bump` calls into the four event handlers.
+5. Manual verify: trigger a run, observe Redis `INCR`, observe next API call returns fresh data.
+
+After Phase 2 → polling still runs at 2 min, but each poll-cycle sees fresh data within one bump.
+
+---
+
+## Phase 3 — Real-time push via SSE
+
+**Backend:**
+- New: `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Models\GitHubEvent.cs` — `{ Type, Owner, Repo, WorkflowId?, RunId?, PullRequestNumber?, DeliveryId }`.
+- New: `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Services\IEventBroadcaster.cs` + `EventBroadcaster.cs` — singleton holding `ConcurrentDictionary<Guid, Channel<GitHubEvent>>` (bounded `Channel<T>` capacity ~64, drop-oldest). `Publish` fans out non-blocking writes. `Subscribe()` → `(Guid, ChannelReader<GitHubEvent>)`.
+- New: `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Handlers\EventStreamHandler.cs` — minimal-API handler. Headers: `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `X-Accel-Buffering: no`. Loop reads from channel + emits `: keepalive\n\n` every 25 s. Honours `HttpContext.RequestAborted`. `Response.Body.FlushAsync()` after each frame.
+- Modify `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Program.cs`: `api.MapGet("events/stream", EventStreamHandler.Handle)` — inside `/api` group so existing session cookie auth applies.
+- Wire `EventBroadcaster.Publish` into each webhook handler right after the Phase 2 version bump.
+
+**Filtering decision:** server pushes all events to every connected session; the frontend filters on selected repos (which live in `localStorage`). Cheaper than threading repo state through the SSE connection.
+
+**Frontend:**
+- New: `K:\Dev\Apps\Wrangler\src\Wrangler.App\src\hooks\useGitHubEventStream.ts` — opens the SSE stream once via the generated SSE helper, holds an `eventType → queryKey-prefix[]` table, calls `queryClient.invalidateQueries({ predicate })` matching on owner/repo:
+  - `workflow_run` → `["getWorkflowRuns", owner, repo]`, `["getWorkflows"]`
+  - `check_run`/`check_suite` → `["getWorkflowRuns", owner, repo]`, `["getWorkflows"]`
+  - `pull_request` → `["pullRequests"]`
+- Modify `K:\Dev\Apps\Wrangler\src\Wrangler.App\src\App.tsx` (or a thin wrapper inside `QueryClientProvider` in `main.tsx`) to mount the hook once for the authenticated layout.
+- Modify `useWorkflowRuns.ts`, `useWorkflows.ts`, `usePullRequests.ts`: raise `staleTime` to `Infinity` and either drop `refetchInterval` or relax to ~10 min as a safety net.
+
+**Granular tasks:**
+1. `GitHubEvent` + `EventBroadcaster` + tests (channel cleanup on cancellation is the tricky part).
+2. `EventStreamHandler` with heartbeat.
+3. Wire broadcaster into `GitHubWebhookEventProcessor`.
+4. Frontend `useGitHubEventStream` hook + mount.
+5. Relax polling on the three hooks.
+6. Verify Azure App Service (Linux) doesn't buffer the SSE response.
+
+After Phase 3 → MVP is done. Real-time dashboard updates.
+
+---
+
+## Phase 4 — UX for App installation
+
+- Modify `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Handlers\CallbackHandler.cs` (lines 28–30): when `installation_id` is present, defensively backfill the registry. Use a one-shot App-JWT call to `GET /app/installations/{id}` + `/installation/repositories`. This is where the `GitHubJwt` package and `GitHubApp:PrivateKeyPem` config are first needed. New service: `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Services\GitHubAppAuthService.cs`.
+- New handler: `K:\Dev\Apps\Wrangler\src\Wrangler.Api\Handlers\InstallationStatusHandler.cs` → `GET /api/installations/status` returns, for the current user's selected repos, which `(owner, repo)` pairs are covered vs uncovered.
+- New frontend component: `K:\Dev\Apps\Wrangler\src\Wrangler.App\src\routes\dashboard\-components\InstallAppBanner.tsx`. Shown when uncovered repos exist; CTA links to `https://github.com/apps/<app-slug>/installations/new`.
+- GitHub App settings: confirm "Post installation Callback URL" → `https://githubactionsdashboard.azurewebsites.net/callback/github`.
+
+**Granular tasks:**
+1. `GitHubAppAuthService` (JWT signing via `GitHubJwt`).
+2. Backfill on callback.
+3. `/api/installations/status` endpoint.
+4. Frontend banner + dismiss state.
+
+---
+
+## Critical files
+
+**New:**
+- `src/Wrangler.Api/Models/GitHubAppOptions.cs`
+- `src/Wrangler.Api/Models/GitHubEvent.cs`
+- `src/Wrangler.Api/Webhooks/GitHubWebhookEventProcessor.cs`
+- `src/Wrangler.Api/Services/IInstallationRegistry.cs` + `InstallationRegistry.cs`
+- `src/Wrangler.Api/Services/IRepoVersionService.cs` + `RepoVersionService.cs`
+- `src/Wrangler.Api/Services/IEventBroadcaster.cs` + `EventBroadcaster.cs`
+- `src/Wrangler.Api/Services/GitHubAppAuthService.cs` (Phase 4)
+- `src/Wrangler.Api/Handlers/EventStreamHandler.cs`
+- `src/Wrangler.Api/Handlers/InstallationStatusHandler.cs` (Phase 4)
+- `src/Wrangler.App/src/hooks/useGitHubEventStream.ts`
+- `src/Wrangler.App/src/routes/dashboard/-components/InstallAppBanner.tsx` (Phase 4)
+
+**Modified:**
+- `src/Wrangler.Api/Wrangler.Api.csproj` — add `Octokit.Webhooks.AspNetCore`, `GitHubJwt` (Phase 4).
+- `src/Wrangler.Api/Program.cs` — DI + routes.
+- `src/Wrangler.Api/Services/DistributedResponseCache.cs` — version-suffix in `GetCacheKey` (line 70).
+- `src/Wrangler.Api/Handlers/CallbackHandler.cs` — replace the no-op `installation_id` branch (Phase 4).
+- `src/Wrangler.App/src/App.tsx` — mount the SSE hook.
+- `src/Wrangler.App/src/routes/dashboard/-hooks/useWorkflows.ts`, `useWorkflowRuns.ts`, `src/routes/pull-requests/-hooks/usePullRequests.ts` — relax polling.
+
+**Reused (do not re-implement):**
+- `Octokit.Webhooks.AspNetCore.WebhookEventProcessor` — base class + `MapGitHubWebhooks` extension; do not hand-roll HMAC.
+- `src/Wrangler.App/src/api/core/serverSentEvents.gen.ts` — generated SSE client.
+- `IDistributedCache` / `IConnectionMultiplexer` already wired in `Program.cs:97-124` (Redis).
+- `CacheKeyService.GetCacheKey` — unchanged; we layer the version suffix inside `DistributedResponseCache` only.
+
+---
+
+## Verification
+
+**Phase 1 — webhook receipt:**
+1. `dotnet run --launch-profile http` against a `smee.io` tunnel pointed at `/webhooks/github`.
+2. Trigger an event on a test repo (push to main, open a PR).
+3. Confirm 200 on the App's Recent Deliveries page.
+4. Hit a duplicate `X-GitHub-Delivery` and confirm the second request short-circuits via the idempotency log line.
+
+**Phase 2 — cache invalidation:**
+1. Hit `/api/workflows` → confirm cache key in Redis (e.g., `redis-cli KEYS '*:gh:GET:/repos/...'`).
+2. Trigger a `workflow_run` event → confirm `INCR` on `gh:ver:{owner}/{repo}:workflow_runs`.
+3. Hit `/api/workflows` again → confirm a fresh outbound GitHub call and a new cache entry with the bumped version suffix.
+
+**Phase 3 — SSE push:**
+1. Open the dashboard; check DevTools → Network → `/api/events/stream` shows `text/event-stream` and stays open.
+2. Trigger a `workflow_run` event → observe an SSE frame in DevTools and React Query invalidating the matching key (use the React Query devtools panel).
+3. Disconnect the network for 30 s, reconnect — confirm SSE re-opens via the generated client's retry logic.
+4. Deploy a Phase 3 build to App Service and re-run (catches any nginx buffering).
+
+**Phase 4 — installation UX:**
+1. Uninstall the App from a test account; reload the dashboard → banner appears.
+2. Click "Install" → complete GitHub install flow → land back on `/callback/github` → banner disappears and matching events start flowing.
+
+---
+
+## Risks / open questions
+
+- **Endpoint-→-kind mapping fragility (Phase 2).** Octokit endpoints can carry query strings and trailing slashes. Mitigate with table-driven tests over a captured corpus of real `IRequest.Endpoint` values.
+- **Delivery retries up to 24 h.** Idempotency window of 10 min is enough — duplicates beyond that just cause one extra refetch (harmless re-bump).
+- **SSE behind Azure App Service (Linux).** Default reverse proxy may buffer. Mitigated via `X-Accel-Buffering: no` + per-frame `FlushAsync`. Verify after first deploy.
+- **Heartbeats.** 25 s comment frames; App Service idle TCP timeout is 240 s — comfortable margin.
+- **Repos not covered by any installation** keep polling. Document and surface via Phase 4 banner.
+- **Octokit GraphQL responses** aren't routed through `IResponseCache` and aren't affected by this work.
+- **Per-user cache vs app-wide webhook.** The version-sidecar approach side-steps the mismatch — webhooks don't need a user context to invalidate, and users still see their own cached responses (just keyed to the latest version after a bump). No need to drop token-hashing.
+- **Webhook firehose volume.** A user on busy orgs may see hundreds of events/minute. Bounded channels + drop-oldest + React Query's debouncing of invalidations keep this safe for a personal-project workload.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,9 +23,9 @@ The frontend API client (`src/GitHubActionsDashboard.App/src/api/`) is auto-gene
 
 To regenerate after backend model/endpoint changes:
 
-1. Start the backend (it must be running on http://localhost:5010):
+1. Start the backend (it must be reachable on http://localhost:5010):
    ```bash
-   cd src/GitHubActionsDashboard.Api && dotnet run --launch-profile http
+   cd src/GitHubActionsDashboard.Api && dotnet run --launch-profile "Full App"
    ```
 2. In a separate shell, regenerate the client:
    ```bash
@@ -33,7 +33,7 @@ To regenerate after backend model/endpoint changes:
    ```
 3. Stop the backend process.
 
-The `http` launch profile runs on port 5010 without HTTPS, which matches the openapi-ts config.
+The `Full App` launch profile listens on both http://localhost:5010 and https://localhost:7010; the http URL matches the openapi-ts config.
 
 ## Key Conventions
 

--- a/src/Wrangler.Api/Handlers/EventStreamHandler.cs
+++ b/src/Wrangler.Api/Handlers/EventStreamHandler.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using Asm.Wrangler.Api.Webhooks;
+
+namespace Asm.Wrangler.Api.Handlers;
+
+/// <summary>
+/// Streams webhook-driven events to connected clients via Server-Sent Events.
+/// </summary>
+public static class EventStreamHandler
+{
+    private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(25);
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public static async Task Handle(HttpContext http, IEventBroadcaster broadcaster, CancellationToken cancellationToken)
+    {
+        http.Response.Headers["Content-Type"] = "text/event-stream";
+        http.Response.Headers["Cache-Control"] = "no-cache";
+        http.Response.Headers["X-Accel-Buffering"] = "no";
+        http.Response.Headers.Connection = "keep-alive";
+
+        using var subscription = broadcaster.Subscribe();
+        await http.Response.Body.FlushAsync(cancellationToken);
+
+        using var heartbeat = new PeriodicTimer(HeartbeatInterval);
+        var heartbeatTask = heartbeat.WaitForNextTickAsync(cancellationToken).AsTask();
+        var readTask = subscription.Reader.WaitToReadAsync(cancellationToken).AsTask();
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var winner = await Task.WhenAny(heartbeatTask, readTask);
+
+            if (winner == heartbeatTask)
+            {
+                if (!await heartbeatTask) break;
+                await http.Response.WriteAsync(": keepalive\n\n", cancellationToken);
+                await http.Response.Body.FlushAsync(cancellationToken);
+                heartbeatTask = heartbeat.WaitForNextTickAsync(cancellationToken).AsTask();
+            }
+            else
+            {
+                if (!await readTask) break;
+                while (subscription.Reader.TryRead(out var evt))
+                {
+                    var payload = JsonSerializer.Serialize(evt, JsonOptions);
+                    await http.Response.WriteAsync($"event: {evt.Type}\ndata: {payload}\n\n", cancellationToken);
+                    await http.Response.Body.FlushAsync(cancellationToken);
+                }
+                readTask = subscription.Reader.WaitToReadAsync(cancellationToken).AsTask();
+            }
+        }
+    }
+}

--- a/src/Wrangler.Api/Models/GitHubAppOptions.cs
+++ b/src/Wrangler.Api/Models/GitHubAppOptions.cs
@@ -1,0 +1,35 @@
+namespace Asm.Wrangler.Api.Models;
+
+/// <summary>
+/// Configuration for the GitHub App used to receive webhook deliveries.
+/// Bound from the <c>GitHubApp</c> configuration section.
+/// </summary>
+public class GitHubAppOptions
+{
+    public const string SectionName = "GitHubApp";
+
+    /// <summary>
+    /// The GitHub App's numeric ID. Required for App-level auth (JWT signing).
+    /// Not used until Phase 4 — installation backfill.
+    /// </summary>
+    public string? AppId { get; init; }
+
+    /// <summary>
+    /// The OAuth client ID associated with the GitHub App. Already present in
+    /// <c>appsettings.json</c> under the top-level <c>ClientId</c> key; mirrored
+    /// here for clarity when binding the full options object.
+    /// </summary>
+    public string? ClientId { get; init; }
+
+    /// <summary>
+    /// The shared secret configured on the GitHub App's webhook settings.
+    /// Used to verify HMAC-SHA256 signatures on incoming webhook deliveries.
+    /// </summary>
+    public string? WebhookSecret { get; init; }
+
+    /// <summary>
+    /// PEM-encoded RSA private key for the GitHub App. Required to mint JWTs
+    /// for App-level API calls (Phase 4).
+    /// </summary>
+    public string? PrivateKeyPem { get; init; }
+}

--- a/src/Wrangler.Api/Models/GitHubEvent.cs
+++ b/src/Wrangler.Api/Models/GitHubEvent.cs
@@ -1,0 +1,17 @@
+namespace Asm.Wrangler.Api.Models;
+
+/// <summary>
+/// A minimal, sanitized notification of a webhook delivery, suitable
+/// for broadcast to connected SSE clients. The payload tells the client
+/// what to invalidate, not what changed.
+/// </summary>
+public record GitHubEvent
+{
+    public required string Type { get; init; }
+    public required string Owner { get; init; }
+    public required string Repo { get; init; }
+    public long? WorkflowId { get; init; }
+    public long? RunId { get; init; }
+    public int? PullRequestNumber { get; init; }
+    public string? DeliveryId { get; init; }
+}

--- a/src/Wrangler.Api/Program.cs
+++ b/src/Wrangler.Api/Program.cs
@@ -5,6 +5,8 @@ using Asm.Wrangler.Api.Exceptions;
 using Asm.Wrangler.Api.Handlers;
 using Asm.Wrangler.Api.Models;
 using Asm.Wrangler.Api.Models.Dashboard;
+using Asm.Wrangler.Api.Webhooks;
+using Octokit.Webhooks.AspNetCore;
 using Asm.Wrangler.Api.OpenApi;
 using Asm.Wrangler.Api.Serialisation;
 using Asm.Wrangler.Api.Services;
@@ -64,11 +66,15 @@ static void AddServices(WebApplicationBuilder builder)
         return new GitHubClient(connection);
     });
 
+    builder.Services.Configure<GitHubAppOptions>(builder.Configuration.GetSection(GitHubAppOptions.SectionName));
+
     builder.Services.AddScoped<IDashboardService, DashboardService>();
     builder.Services.AddScoped<ISettingsService, SettingsService>();
     builder.Services.AddScoped<IPullRequestService, PullRequestService>();
     builder.Services.AddSingleton<ICacheKeyService, CacheKeyService>();
     builder.Services.AddSingleton<IResponseCache, DistributedResponseCache>();
+    builder.Services.AddSingleton<IInstallationRegistry, InstallationRegistry>();
+    builder.Services.AddSingleton<Octokit.Webhooks.WebhookEventProcessor, GitHubWebhookEventProcessor>();
 
     builder.Services.AddOpenApi("v1", options =>
     {
@@ -213,6 +219,9 @@ static void AddApp(WebApplication app)
 
     app.MapGet("/callback/github", CallbackHandler.Handle).ExcludeFromDescription();
     app.MapGet("/login/github", LoginHandler.Handle).ExcludeFromDescription();
+
+    var webhookSecret = app.Configuration.GetSection(GitHubAppOptions.SectionName)[nameof(GitHubAppOptions.WebhookSecret)];
+    app.MapGitHubWebhooks("/webhooks/github", webhookSecret).AllowAnonymous().ExcludeFromDescription().DisableAntiforgery();
 
     if (app.Environment.IsDevelopment())
     {

--- a/src/Wrangler.Api/Program.cs
+++ b/src/Wrangler.Api/Program.cs
@@ -74,6 +74,7 @@ static void AddServices(WebApplicationBuilder builder)
     builder.Services.AddSingleton<ICacheKeyService, CacheKeyService>();
     builder.Services.AddSingleton<IResponseCache, DistributedResponseCache>();
     builder.Services.AddSingleton<IInstallationRegistry, InstallationRegistry>();
+    builder.Services.AddSingleton<IRepoVersionService, RepoVersionService>();
     builder.Services.AddSingleton<Octokit.Webhooks.WebhookEventProcessor, GitHubWebhookEventProcessor>();
 
     builder.Services.AddOpenApi("v1", options =>

--- a/src/Wrangler.Api/Program.cs
+++ b/src/Wrangler.Api/Program.cs
@@ -75,6 +75,7 @@ static void AddServices(WebApplicationBuilder builder)
     builder.Services.AddSingleton<IResponseCache, DistributedResponseCache>();
     builder.Services.AddSingleton<IInstallationRegistry, InstallationRegistry>();
     builder.Services.AddSingleton<IRepoVersionService, RepoVersionService>();
+    builder.Services.AddSingleton<IEventBroadcaster, EventBroadcaster>();
     builder.Services.AddSingleton<Octokit.Webhooks.WebhookEventProcessor, GitHubWebhookEventProcessor>();
 
     builder.Services.AddOpenApi("v1", options =>
@@ -257,6 +258,8 @@ static void AddApp(WebApplication app)
 
     api.MapPost("pull-requests", PullRequestsHandler.Handle).DisableAntiforgery();
     api.MapPost("pull-requests/approve", ApprovePullRequestsHandler.Handle);
+
+    api.MapGet("events/stream", EventStreamHandler.Handle).ExcludeFromDescription();
 
     app.UseSecurityHeaders();
 

--- a/src/Wrangler.Api/Properties/launchSettings.json
+++ b/src/Wrangler.Api/Properties/launchSettings.json
@@ -8,17 +8,7 @@
       "dotnetRunMessages": true,
       "applicationUrl": "https://localhost:7010;http://localhost:5010"
     },
-    "http": {
-      "commandName": "Project",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.SpaProxy"
-      },
-      "dotnetRunMessages": true,
-      "applicationUrl": "http://localhost:5010"
-    },
-    "https": {
+    "Full App": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
@@ -27,17 +17,6 @@
       },
       "dotnetRunMessages": true,
       "applicationUrl": "https://localhost:7010;http://localhost:5010"
-    },
-    "Container (Dockerfile)": {
-      "commandName": "Docker",
-      "launchBrowser": true,
-      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}",
-      "environmentVariables": {
-        "ASPNETCORE_HTTPS_PORTS": "8081",
-        "ASPNETCORE_HTTP_PORTS": "8080"
-      },
-      "publishAllPorts": true,
-      "useSSL": true
     }
   },
   "$schema": "https://json.schemastore.org/launchsettings.json"

--- a/src/Wrangler.Api/Services/DistributedResponseCache.cs
+++ b/src/Wrangler.Api/Services/DistributedResponseCache.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using Asm.Wrangler.Api.Webhooks;
 using Microsoft.Extensions.Caching.Distributed;
 using Newtonsoft.Json;
 using Octokit.Caching;
@@ -9,12 +10,12 @@ namespace Asm.Wrangler.Api.Services;
 /// <summary>
 /// An Octokit response cache backed by <see cref="IDistributedCache"/>.
 /// </summary>
-public class DistributedResponseCache(IDistributedCache cache, ICacheKeyService cacheKeyService, ILogger<DistributedResponseCache> logger) : IResponseCache
+public class DistributedResponseCache(IDistributedCache cache, ICacheKeyService cacheKeyService, IRepoVersionService repoVersions, ILogger<DistributedResponseCache> logger) : IResponseCache
 {
     /// <inheritdoc />
     public async Task<CachedResponse.V1?> GetAsync(IRequest request)
     {
-        var cacheKey = GetCacheKey(request);
+        var cacheKey = await GetCacheKeyAsync(request);
 
         try
         {
@@ -51,7 +52,7 @@ public class DistributedResponseCache(IDistributedCache cache, ICacheKeyService 
     {
         try
         {
-            var cacheKey = GetCacheKey(request);
+            var cacheKey = await GetCacheKeyAsync(request);
 
             var json = JsonConvert.SerializeObject(cachedResponse);
             await cache.SetStringAsync(cacheKey, json, new DistributedCacheEntryOptions
@@ -67,7 +68,7 @@ public class DistributedResponseCache(IDistributedCache cache, ICacheKeyService 
         }
     }
 
-    private string GetCacheKey(IRequest request)
+    private async Task<string> GetCacheKeyAsync(IRequest request)
     {
         // Create a cache key from the request URL and parameters
         var keyBuilder = new StringBuilder();
@@ -85,6 +86,15 @@ public class DistributedResponseCache(IDistributedCache cache, ICacheKeyService 
                 keyBuilder.Append(param.Value);
                 keyBuilder.Append('&');
             }
+        }
+
+        // Fold in the per-repo version stamp so webhook bumps orphan stale
+        // entries naturally on the next read.
+        if (EndpointKindMapper.TryMap(request.Endpoint.ToString(), out var owner, out var repo, out var kind))
+        {
+            var version = await repoVersions.GetVersionAsync(owner, repo, kind, CancellationToken.None);
+            keyBuilder.Append(":v");
+            keyBuilder.Append(version);
         }
 
         return cacheKeyService.GetCacheKey($"gh:{keyBuilder.ToString().TrimEnd('&')}");

--- a/src/Wrangler.Api/Webhooks/EndpointKindMapper.cs
+++ b/src/Wrangler.Api/Webhooks/EndpointKindMapper.cs
@@ -1,0 +1,93 @@
+namespace Asm.Wrangler.Api.Webhooks;
+
+/// <summary>
+/// Maps Octokit endpoint paths to a (owner, repo, kind) tuple so the
+/// response cache can apply the matching per-repo version stamp.
+/// Unmapped paths return <c>false</c> and bypass versioning.
+/// </summary>
+public static class EndpointKindMapper
+{
+    public static bool TryMap(string endpoint, out string owner, out string repo, out RepoDataKind kind)
+    {
+        owner = String.Empty;
+        repo = String.Empty;
+        kind = default;
+
+        if (String.IsNullOrEmpty(endpoint)) return false;
+
+        // Strip any query string — kind is determined by the path only.
+        var path = endpoint;
+        var queryIdx = path.IndexOf('?');
+        if (queryIdx >= 0) path = path[..queryIdx];
+
+        var segments = path.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+        // Every supported path starts with "/repos/{owner}/{repo}/..." with
+        // at least one tail segment.
+        if (segments.Length < 4) return false;
+        if (!String.Equals(segments[0], "repos", StringComparison.OrdinalIgnoreCase)) return false;
+
+        owner = segments[1];
+        repo = segments[2];
+        var tail = segments[3];
+
+        // Tail-based dispatch. Order matters where one prefix is a subset of
+        // another (e.g. workflows vs workflows/{id}/runs).
+        if (String.Equals(tail, "actions", StringComparison.OrdinalIgnoreCase))
+        {
+            if (segments.Length >= 5)
+            {
+                var sub = segments[4];
+                // /repos/{o}/{r}/actions/workflows/{id}/runs → workflow_runs
+                if (String.Equals(sub, "workflows", StringComparison.OrdinalIgnoreCase) && segments.Length >= 7 &&
+                    String.Equals(segments[6], "runs", StringComparison.OrdinalIgnoreCase))
+                {
+                    kind = RepoDataKind.WorkflowRuns;
+                    return true;
+                }
+                // /repos/{o}/{r}/actions/workflows[...] → workflows
+                if (String.Equals(sub, "workflows", StringComparison.OrdinalIgnoreCase))
+                {
+                    kind = RepoDataKind.Workflows;
+                    return true;
+                }
+                // /repos/{o}/{r}/actions/runs[...] → workflow_runs
+                if (String.Equals(sub, "runs", StringComparison.OrdinalIgnoreCase))
+                {
+                    kind = RepoDataKind.WorkflowRuns;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if (String.Equals(tail, "pulls", StringComparison.OrdinalIgnoreCase))
+        {
+            kind = RepoDataKind.Pulls;
+            return true;
+        }
+
+        if (String.Equals(tail, "check-runs", StringComparison.OrdinalIgnoreCase) ||
+            String.Equals(tail, "check-suites", StringComparison.OrdinalIgnoreCase) ||
+            String.Equals(tail, "commits", StringComparison.OrdinalIgnoreCase))
+        {
+            // /repos/{o}/{r}/commits/{sha}/check-runs and /commits/{sha}/status
+            // both feed the check-status surface; bucket under Checks.
+            if (String.Equals(tail, "commits", StringComparison.OrdinalIgnoreCase))
+            {
+                if (segments.Length >= 6 &&
+                    (String.Equals(segments[5], "check-runs", StringComparison.OrdinalIgnoreCase) ||
+                     String.Equals(segments[5], "status", StringComparison.OrdinalIgnoreCase)))
+                {
+                    kind = RepoDataKind.Checks;
+                    return true;
+                }
+                return false;
+            }
+            kind = RepoDataKind.Checks;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Wrangler.Api/Webhooks/EventBroadcaster.cs
+++ b/src/Wrangler.Api/Webhooks/EventBroadcaster.cs
@@ -1,0 +1,41 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+using Asm.Wrangler.Api.Models;
+
+namespace Asm.Wrangler.Api.Webhooks;
+
+internal class EventBroadcaster : IEventBroadcaster
+{
+    private const int SubscriberQueueCapacity = 64;
+
+    private readonly ConcurrentDictionary<Guid, Channel<GitHubEvent>> _subscribers = new();
+
+    public EventSubscription Subscribe()
+    {
+        var id = Guid.NewGuid();
+        var channel = Channel.CreateBounded<GitHubEvent>(new BoundedChannelOptions(SubscriberQueueCapacity)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false,
+        });
+        _subscribers[id] = channel;
+        return new EventSubscription(id, channel.Reader, Unsubscribe);
+    }
+
+    public void Publish(GitHubEvent evt)
+    {
+        foreach (var subscriber in _subscribers.Values)
+        {
+            subscriber.Writer.TryWrite(evt);
+        }
+    }
+
+    private void Unsubscribe(Guid id)
+    {
+        if (_subscribers.TryRemove(id, out var channel))
+        {
+            channel.Writer.TryComplete();
+        }
+    }
+}

--- a/src/Wrangler.Api/Webhooks/GitHubWebhookEventProcessor.cs
+++ b/src/Wrangler.Api/Webhooks/GitHubWebhookEventProcessor.cs
@@ -1,3 +1,4 @@
+using Asm.Wrangler.Api.Models;
 using Octokit.Webhooks;
 using Octokit.Webhooks.Events;
 using Octokit.Webhooks.Events.CheckRun;
@@ -17,6 +18,7 @@ namespace Asm.Wrangler.Api.Webhooks;
 internal sealed class GitHubWebhookEventProcessor(
     IInstallationRegistry registry,
     IRepoVersionService versions,
+    IEventBroadcaster broadcaster,
     ILogger<GitHubWebhookEventProcessor> logger) : WebhookEventProcessor
 {
     // pull_request actions that change check status or PR list visibility;
@@ -38,6 +40,7 @@ internal sealed class GitHubWebhookEventProcessor(
         logger.LogInformation("workflow_run.{Action} {Owner}/{Repo} run={RunId}", action, owner, repo, workflowRunEvent.WorkflowRun.Id);
         await BumpAsync(owner, repo, RepoDataKind.WorkflowRuns, cancellationToken);
         await BumpAsync(owner, repo, RepoDataKind.Workflows, cancellationToken);
+        Broadcast("workflow_run", owner, repo, headers, workflowId: (long)workflowRunEvent.WorkflowRun.WorkflowId, runId: (long)workflowRunEvent.WorkflowRun.Id);
     }
 
     protected override async ValueTask ProcessPullRequestWebhookAsync(WebhookHeaders headers, PullRequestEvent pullRequestEvent, PullRequestAction action, CancellationToken cancellationToken = default)
@@ -48,6 +51,7 @@ internal sealed class GitHubWebhookEventProcessor(
         if (InvalidatingPullRequestActions.Contains(action))
         {
             await BumpAsync(owner, repo, RepoDataKind.Pulls, cancellationToken);
+            Broadcast("pull_request", owner, repo, headers, pullRequestNumber: (int)pullRequestEvent.PullRequest.Number);
         }
     }
 
@@ -58,6 +62,7 @@ internal sealed class GitHubWebhookEventProcessor(
         logger.LogInformation("check_run.{Action} {Owner}/{Repo} name={Name}", action, owner, repo, checkRunEvent.CheckRun.Name);
         await BumpAsync(owner, repo, RepoDataKind.Checks, cancellationToken);
         await BumpAsync(owner, repo, RepoDataKind.WorkflowRuns, cancellationToken);
+        Broadcast("check_run", owner, repo, headers);
     }
 
     protected override async ValueTask ProcessCheckSuiteWebhookAsync(WebhookHeaders headers, CheckSuiteEvent checkSuiteEvent, CheckSuiteAction action, CancellationToken cancellationToken = default)
@@ -67,6 +72,22 @@ internal sealed class GitHubWebhookEventProcessor(
         logger.LogInformation("check_suite.{Action} {Owner}/{Repo} id={Id}", action, owner, repo, checkSuiteEvent.CheckSuite.Id);
         await BumpAsync(owner, repo, RepoDataKind.Checks, cancellationToken);
         await BumpAsync(owner, repo, RepoDataKind.WorkflowRuns, cancellationToken);
+        Broadcast("check_suite", owner, repo, headers);
+    }
+
+    private void Broadcast(string type, string? owner, string? repo, WebhookHeaders headers, long? workflowId = null, long? runId = null, int? pullRequestNumber = null)
+    {
+        if (String.IsNullOrEmpty(owner) || String.IsNullOrEmpty(repo)) return;
+        broadcaster.Publish(new GitHubEvent
+        {
+            Type = type,
+            Owner = owner,
+            Repo = repo,
+            WorkflowId = workflowId,
+            RunId = runId,
+            PullRequestNumber = pullRequestNumber,
+            DeliveryId = headers.Delivery,
+        });
     }
 
     private async ValueTask BumpAsync(string? owner, string? repo, RepoDataKind kind, CancellationToken cancellationToken)

--- a/src/Wrangler.Api/Webhooks/GitHubWebhookEventProcessor.cs
+++ b/src/Wrangler.Api/Webhooks/GitHubWebhookEventProcessor.cs
@@ -16,31 +16,67 @@ namespace Asm.Wrangler.Api.Webhooks;
 /// </summary>
 internal sealed class GitHubWebhookEventProcessor(
     IInstallationRegistry registry,
+    IRepoVersionService versions,
     ILogger<GitHubWebhookEventProcessor> logger) : WebhookEventProcessor
 {
+    // pull_request actions that change check status or PR list visibility;
+    // anything else (label/assign/review_requested/...) is noise for our UI.
+    private static readonly HashSet<PullRequestAction> InvalidatingPullRequestActions =
+    [
+        PullRequestAction.Opened,
+        PullRequestAction.Closed,
+        PullRequestAction.Reopened,
+        PullRequestAction.Synchronize,
+        PullRequestAction.Edited,
+        PullRequestAction.ReadyForReview,
+    ];
+
     protected override async ValueTask ProcessWorkflowRunWebhookAsync(WebhookHeaders headers, WorkflowRunEvent workflowRunEvent, WorkflowRunAction action, CancellationToken cancellationToken = default)
     {
         if (!await ClaimAsync(headers, cancellationToken)) return;
-        logger.LogInformation("workflow_run.{Action} {Owner}/{Repo} run={RunId}", action, workflowRunEvent.Repository?.Owner.Login, workflowRunEvent.Repository?.Name, workflowRunEvent.WorkflowRun.Id);
+        var (owner, repo) = RepoOf(workflowRunEvent.Repository);
+        logger.LogInformation("workflow_run.{Action} {Owner}/{Repo} run={RunId}", action, owner, repo, workflowRunEvent.WorkflowRun.Id);
+        await BumpAsync(owner, repo, RepoDataKind.WorkflowRuns, cancellationToken);
+        await BumpAsync(owner, repo, RepoDataKind.Workflows, cancellationToken);
     }
 
     protected override async ValueTask ProcessPullRequestWebhookAsync(WebhookHeaders headers, PullRequestEvent pullRequestEvent, PullRequestAction action, CancellationToken cancellationToken = default)
     {
         if (!await ClaimAsync(headers, cancellationToken)) return;
-        logger.LogInformation("pull_request.{Action} {Owner}/{Repo} #{Number}", action, pullRequestEvent.Repository?.Owner.Login, pullRequestEvent.Repository?.Name, pullRequestEvent.PullRequest.Number);
+        var (owner, repo) = RepoOf(pullRequestEvent.Repository);
+        logger.LogInformation("pull_request.{Action} {Owner}/{Repo} #{Number}", action, owner, repo, pullRequestEvent.PullRequest.Number);
+        if (InvalidatingPullRequestActions.Contains(action))
+        {
+            await BumpAsync(owner, repo, RepoDataKind.Pulls, cancellationToken);
+        }
     }
 
     protected override async ValueTask ProcessCheckRunWebhookAsync(WebhookHeaders headers, CheckRunEvent checkRunEvent, CheckRunAction action, CancellationToken cancellationToken = default)
     {
         if (!await ClaimAsync(headers, cancellationToken)) return;
-        logger.LogInformation("check_run.{Action} {Owner}/{Repo} name={Name}", action, checkRunEvent.Repository?.Owner.Login, checkRunEvent.Repository?.Name, checkRunEvent.CheckRun.Name);
+        var (owner, repo) = RepoOf(checkRunEvent.Repository);
+        logger.LogInformation("check_run.{Action} {Owner}/{Repo} name={Name}", action, owner, repo, checkRunEvent.CheckRun.Name);
+        await BumpAsync(owner, repo, RepoDataKind.Checks, cancellationToken);
+        await BumpAsync(owner, repo, RepoDataKind.WorkflowRuns, cancellationToken);
     }
 
     protected override async ValueTask ProcessCheckSuiteWebhookAsync(WebhookHeaders headers, CheckSuiteEvent checkSuiteEvent, CheckSuiteAction action, CancellationToken cancellationToken = default)
     {
         if (!await ClaimAsync(headers, cancellationToken)) return;
-        logger.LogInformation("check_suite.{Action} {Owner}/{Repo} id={Id}", action, checkSuiteEvent.Repository?.Owner.Login, checkSuiteEvent.Repository?.Name, checkSuiteEvent.CheckSuite.Id);
+        var (owner, repo) = RepoOf(checkSuiteEvent.Repository);
+        logger.LogInformation("check_suite.{Action} {Owner}/{Repo} id={Id}", action, owner, repo, checkSuiteEvent.CheckSuite.Id);
+        await BumpAsync(owner, repo, RepoDataKind.Checks, cancellationToken);
+        await BumpAsync(owner, repo, RepoDataKind.WorkflowRuns, cancellationToken);
     }
+
+    private async ValueTask BumpAsync(string? owner, string? repo, RepoDataKind kind, CancellationToken cancellationToken)
+    {
+        if (String.IsNullOrEmpty(owner) || String.IsNullOrEmpty(repo)) return;
+        await versions.BumpAsync(owner, repo, kind, cancellationToken);
+    }
+
+    private static (string? Owner, string? Repo) RepoOf(Octokit.Webhooks.Models.Repository? repository) =>
+        (repository?.Owner.Login, repository?.Name);
 
     protected override async ValueTask ProcessInstallationWebhookAsync(WebhookHeaders headers, InstallationEvent installationEvent, InstallationAction action, CancellationToken cancellationToken = default)
     {

--- a/src/Wrangler.Api/Webhooks/GitHubWebhookEventProcessor.cs
+++ b/src/Wrangler.Api/Webhooks/GitHubWebhookEventProcessor.cs
@@ -1,0 +1,116 @@
+using Octokit.Webhooks;
+using Octokit.Webhooks.Events;
+using Octokit.Webhooks.Events.CheckRun;
+using Octokit.Webhooks.Events.CheckSuite;
+using Octokit.Webhooks.Events.Installation;
+using Octokit.Webhooks.Events.InstallationRepositories;
+using Octokit.Webhooks.Events.PullRequest;
+using Octokit.Webhooks.Events.WorkflowRun;
+
+namespace Asm.Wrangler.Api.Webhooks;
+
+/// <summary>
+/// Receives GitHub App webhook deliveries. Phase 1: log-only with delivery dedupe,
+/// plus maintain the installation registry. Cache invalidation and event broadcasting
+/// arrive in later phases.
+/// </summary>
+internal sealed class GitHubWebhookEventProcessor(
+    IInstallationRegistry registry,
+    ILogger<GitHubWebhookEventProcessor> logger) : WebhookEventProcessor
+{
+    protected override async ValueTask ProcessWorkflowRunWebhookAsync(WebhookHeaders headers, WorkflowRunEvent workflowRunEvent, WorkflowRunAction action, CancellationToken cancellationToken = default)
+    {
+        if (!await ClaimAsync(headers, cancellationToken)) return;
+        logger.LogInformation("workflow_run.{Action} {Owner}/{Repo} run={RunId}", action, workflowRunEvent.Repository?.Owner.Login, workflowRunEvent.Repository?.Name, workflowRunEvent.WorkflowRun.Id);
+    }
+
+    protected override async ValueTask ProcessPullRequestWebhookAsync(WebhookHeaders headers, PullRequestEvent pullRequestEvent, PullRequestAction action, CancellationToken cancellationToken = default)
+    {
+        if (!await ClaimAsync(headers, cancellationToken)) return;
+        logger.LogInformation("pull_request.{Action} {Owner}/{Repo} #{Number}", action, pullRequestEvent.Repository?.Owner.Login, pullRequestEvent.Repository?.Name, pullRequestEvent.PullRequest.Number);
+    }
+
+    protected override async ValueTask ProcessCheckRunWebhookAsync(WebhookHeaders headers, CheckRunEvent checkRunEvent, CheckRunAction action, CancellationToken cancellationToken = default)
+    {
+        if (!await ClaimAsync(headers, cancellationToken)) return;
+        logger.LogInformation("check_run.{Action} {Owner}/{Repo} name={Name}", action, checkRunEvent.Repository?.Owner.Login, checkRunEvent.Repository?.Name, checkRunEvent.CheckRun.Name);
+    }
+
+    protected override async ValueTask ProcessCheckSuiteWebhookAsync(WebhookHeaders headers, CheckSuiteEvent checkSuiteEvent, CheckSuiteAction action, CancellationToken cancellationToken = default)
+    {
+        if (!await ClaimAsync(headers, cancellationToken)) return;
+        logger.LogInformation("check_suite.{Action} {Owner}/{Repo} id={Id}", action, checkSuiteEvent.Repository?.Owner.Login, checkSuiteEvent.Repository?.Name, checkSuiteEvent.CheckSuite.Id);
+    }
+
+    protected override async ValueTask ProcessInstallationWebhookAsync(WebhookHeaders headers, InstallationEvent installationEvent, InstallationAction action, CancellationToken cancellationToken = default)
+    {
+        if (!await ClaimAsync(headers, cancellationToken)) return;
+
+        var installation = installationEvent.Installation;
+        var info = new InstallationInfo
+        {
+            Account = installation.Account.Login,
+            AccountId = (long)installation.Account.Id,
+            Type = installation.Account.Type?.ToString() ?? "User",
+        };
+        var repos = installationEvent.Repositories?.Select(r => r.FullName) ?? [];
+
+        if (action == InstallationAction.Created)
+        {
+            await registry.SaveInstallationAsync((long)installation.Id, info, repos, cancellationToken);
+            logger.LogInformation("installation.created id={Id} account={Account}", installation.Id, info.Account);
+        }
+        else if (action == InstallationAction.Deleted)
+        {
+            await registry.RemoveInstallationAsync((long)installation.Id, cancellationToken);
+            logger.LogInformation("installation.deleted id={Id}", installation.Id);
+        }
+        else if (action == InstallationAction.Suspend)
+        {
+            await registry.SetSuspendedAsync((long)installation.Id, suspended: true, cancellationToken);
+            logger.LogInformation("installation.suspend id={Id}", installation.Id);
+        }
+        else if (action == InstallationAction.Unsuspend)
+        {
+            await registry.SetSuspendedAsync((long)installation.Id, suspended: false, cancellationToken);
+            logger.LogInformation("installation.unsuspend id={Id}", installation.Id);
+        }
+        else
+        {
+            logger.LogInformation("installation.{Action} id={Id} (no-op)", action, installation.Id);
+        }
+    }
+
+    protected override async ValueTask ProcessInstallationRepositoriesWebhookAsync(WebhookHeaders headers, InstallationRepositoriesEvent installationRepositoriesEvent, InstallationRepositoriesAction action, CancellationToken cancellationToken = default)
+    {
+        if (!await ClaimAsync(headers, cancellationToken)) return;
+
+        var installationId = (long)installationRepositoriesEvent.Installation.Id;
+
+        if (action == InstallationRepositoriesAction.Added)
+        {
+            var added = installationRepositoriesEvent.RepositoriesAdded?.Select(r => r.FullName) ?? [];
+            await registry.AddRepositoriesAsync(installationId, added, cancellationToken);
+            logger.LogInformation("installation_repositories.added id={Id} count={Count}", installationId, added.Count());
+        }
+        else if (action == InstallationRepositoriesAction.Removed)
+        {
+            var removed = installationRepositoriesEvent.RepositoriesRemoved?.Select(r => r.FullName) ?? [];
+            await registry.RemoveRepositoriesAsync(installationId, removed, cancellationToken);
+            logger.LogInformation("installation_repositories.removed id={Id} count={Count}", installationId, removed.Count());
+        }
+    }
+
+    private async ValueTask<bool> ClaimAsync(WebhookHeaders headers, CancellationToken cancellationToken)
+    {
+        var deliveryId = headers.Delivery;
+        if (String.IsNullOrEmpty(deliveryId)) return true;
+
+        var first = await registry.TryClaimDeliveryAsync(deliveryId, cancellationToken);
+        if (!first)
+        {
+            logger.LogDebug("Duplicate webhook delivery {DeliveryId} ignored.", deliveryId);
+        }
+        return first;
+    }
+}

--- a/src/Wrangler.Api/Webhooks/IEventBroadcaster.cs
+++ b/src/Wrangler.Api/Webhooks/IEventBroadcaster.cs
@@ -1,0 +1,34 @@
+using System.Threading.Channels;
+using Asm.Wrangler.Api.Models;
+
+namespace Asm.Wrangler.Api.Webhooks;
+
+/// <summary>
+/// In-process fan-out of webhook events to active SSE subscribers.
+/// </summary>
+public interface IEventBroadcaster
+{
+    /// <summary>
+    /// Registers a new subscriber. Dispose the returned subscription to
+    /// stop receiving events.
+    /// </summary>
+    EventSubscription Subscribe();
+
+    /// <summary>
+    /// Fans out an event to every active subscriber. Slow consumers drop
+    /// older queued events rather than blocking the publisher.
+    /// </summary>
+    void Publish(GitHubEvent evt);
+}
+
+/// <summary>
+/// A live SSE subscription. Disposing it removes the subscriber from
+/// the broadcaster.
+/// </summary>
+public sealed class EventSubscription(Guid id, ChannelReader<GitHubEvent> reader, Action<Guid> onDispose) : IDisposable
+{
+    public Guid Id { get; } = id;
+    public ChannelReader<GitHubEvent> Reader { get; } = reader;
+
+    public void Dispose() => onDispose(Id);
+}

--- a/src/Wrangler.Api/Webhooks/IInstallationRegistry.cs
+++ b/src/Wrangler.Api/Webhooks/IInstallationRegistry.cs
@@ -1,0 +1,39 @@
+namespace Asm.Wrangler.Api.Webhooks;
+
+/// <summary>
+/// Metadata for a GitHub App installation on a user or organisation account.
+/// </summary>
+public record InstallationInfo
+{
+    public required string Account { get; init; }
+    public required long AccountId { get; init; }
+    /// <summary>"User" or "Organization".</summary>
+    public required string Type { get; init; }
+    public DateTimeOffset? SuspendedAt { get; init; }
+}
+
+/// <summary>
+/// Tracks GitHub App installations and which repositories each covers.
+/// Backed by the distributed cache (Redis in prod, in-memory in dev).
+/// </summary>
+public interface IInstallationRegistry
+{
+    Task SaveInstallationAsync(long installationId, InstallationInfo info, IEnumerable<string> repos, CancellationToken cancellationToken);
+
+    Task RemoveInstallationAsync(long installationId, CancellationToken cancellationToken);
+
+    Task SetSuspendedAsync(long installationId, bool suspended, CancellationToken cancellationToken);
+
+    Task AddRepositoriesAsync(long installationId, IEnumerable<string> repos, CancellationToken cancellationToken);
+
+    Task RemoveRepositoriesAsync(long installationId, IEnumerable<string> repos, CancellationToken cancellationToken);
+
+    Task<long?> GetInstallationIdForRepoAsync(string owner, string repo, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Atomically records that a webhook delivery has been processed.
+    /// Returns <c>true</c> on the first call for a given delivery ID,
+    /// <c>false</c> on subsequent calls within the dedupe window.
+    /// </summary>
+    Task<bool> TryClaimDeliveryAsync(string deliveryId, CancellationToken cancellationToken);
+}

--- a/src/Wrangler.Api/Webhooks/IRepoVersionService.cs
+++ b/src/Wrangler.Api/Webhooks/IRepoVersionService.cs
@@ -1,0 +1,19 @@
+namespace Asm.Wrangler.Api.Webhooks;
+
+/// <summary>
+/// Per-(owner, repo, kind) freshness stamps used to invalidate cached GitHub
+/// responses when a webhook reports a change. A monotonic stamp is folded
+/// into cache keys so bumping it orphans the previous entries naturally.
+/// </summary>
+public interface IRepoVersionService
+{
+    /// <summary>
+    /// Returns the current stamp, or 0 when no bump has been recorded.
+    /// </summary>
+    Task<long> GetVersionAsync(string owner, string repo, RepoDataKind kind, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Records a fresh stamp so subsequent cache reads miss and re-fetch.
+    /// </summary>
+    Task BumpAsync(string owner, string repo, RepoDataKind kind, CancellationToken cancellationToken);
+}

--- a/src/Wrangler.Api/Webhooks/InstallationRegistry.cs
+++ b/src/Wrangler.Api/Webhooks/InstallationRegistry.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Asm.Wrangler.Api.Webhooks;
+
+internal class InstallationRegistry(IDistributedCache cache) : IInstallationRegistry
+{
+    private static readonly TimeSpan DeliveryDedupeWindow = TimeSpan.FromMinutes(10);
+
+    private static string InstallationKey(long id) => $"gh:install:{id}";
+    private static string InstallationReposKey(long id) => $"gh:install:{id}:repos";
+    private static string RepoLookupKey(string owner, string repo) => $"gh:repo:{owner}/{repo}:install";
+    private static string DeliveryKey(string deliveryId) => $"gh:delivery:{deliveryId}";
+
+    public async Task SaveInstallationAsync(long installationId, InstallationInfo info, IEnumerable<string> repos, CancellationToken cancellationToken)
+    {
+        await cache.SetStringAsync(InstallationKey(installationId), JsonSerializer.Serialize(info), cancellationToken);
+
+        var repoList = repos.Distinct().ToList();
+        await cache.SetStringAsync(InstallationReposKey(installationId), JsonSerializer.Serialize(repoList), cancellationToken);
+
+        foreach (var repo in repoList)
+        {
+            await cache.SetStringAsync(RepoLookupKey(SplitOwner(repo), SplitRepo(repo)), installationId.ToString(), cancellationToken);
+        }
+    }
+
+    public async Task RemoveInstallationAsync(long installationId, CancellationToken cancellationToken)
+    {
+        var repos = await GetRepositoriesAsync(installationId, cancellationToken);
+
+        foreach (var repo in repos)
+        {
+            await cache.RemoveAsync(RepoLookupKey(SplitOwner(repo), SplitRepo(repo)), cancellationToken);
+        }
+
+        await cache.RemoveAsync(InstallationReposKey(installationId), cancellationToken);
+        await cache.RemoveAsync(InstallationKey(installationId), cancellationToken);
+    }
+
+    public async Task SetSuspendedAsync(long installationId, bool suspended, CancellationToken cancellationToken)
+    {
+        var existing = await cache.GetStringAsync(InstallationKey(installationId), cancellationToken);
+        if (String.IsNullOrEmpty(existing)) return;
+
+        var info = JsonSerializer.Deserialize<InstallationInfo>(existing);
+        if (info is null) return;
+
+        var updated = info with { SuspendedAt = suspended ? DateTimeOffset.UtcNow : null };
+        await cache.SetStringAsync(InstallationKey(installationId), JsonSerializer.Serialize(updated), cancellationToken);
+    }
+
+    public async Task AddRepositoriesAsync(long installationId, IEnumerable<string> repos, CancellationToken cancellationToken)
+    {
+        var current = await GetRepositoriesAsync(installationId, cancellationToken);
+        var merged = current.Concat(repos).Distinct().ToList();
+        await cache.SetStringAsync(InstallationReposKey(installationId), JsonSerializer.Serialize(merged), cancellationToken);
+
+        foreach (var repo in repos.Distinct())
+        {
+            await cache.SetStringAsync(RepoLookupKey(SplitOwner(repo), SplitRepo(repo)), installationId.ToString(), cancellationToken);
+        }
+    }
+
+    public async Task RemoveRepositoriesAsync(long installationId, IEnumerable<string> repos, CancellationToken cancellationToken)
+    {
+        var toRemove = repos.Distinct().ToHashSet(StringComparer.Ordinal);
+        var current = await GetRepositoriesAsync(installationId, cancellationToken);
+        var remaining = current.Where(r => !toRemove.Contains(r)).ToList();
+        await cache.SetStringAsync(InstallationReposKey(installationId), JsonSerializer.Serialize(remaining), cancellationToken);
+
+        foreach (var repo in toRemove)
+        {
+            await cache.RemoveAsync(RepoLookupKey(SplitOwner(repo), SplitRepo(repo)), cancellationToken);
+        }
+    }
+
+    public async Task<long?> GetInstallationIdForRepoAsync(string owner, string repo, CancellationToken cancellationToken)
+    {
+        var value = await cache.GetStringAsync(RepoLookupKey(owner, repo), cancellationToken);
+        return Int64.TryParse(value, out var id) ? id : null;
+    }
+
+    public async Task<bool> TryClaimDeliveryAsync(string deliveryId, CancellationToken cancellationToken)
+    {
+        var key = DeliveryKey(deliveryId);
+
+        var existing = await cache.GetStringAsync(key, cancellationToken);
+        if (!String.IsNullOrEmpty(existing)) return false;
+
+        await cache.SetStringAsync(key, "1", new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = DeliveryDedupeWindow,
+        }, cancellationToken);
+
+        return true;
+    }
+
+    private async Task<List<string>> GetRepositoriesAsync(long installationId, CancellationToken cancellationToken)
+    {
+        var json = await cache.GetStringAsync(InstallationReposKey(installationId), cancellationToken);
+        if (String.IsNullOrEmpty(json)) return [];
+
+        return JsonSerializer.Deserialize<List<string>>(json) ?? [];
+    }
+
+    private static string SplitOwner(string ownerSlashRepo)
+    {
+        var idx = ownerSlashRepo.IndexOf('/');
+        return idx < 0 ? ownerSlashRepo : ownerSlashRepo[..idx];
+    }
+
+    private static string SplitRepo(string ownerSlashRepo)
+    {
+        var idx = ownerSlashRepo.IndexOf('/');
+        return idx < 0 ? String.Empty : ownerSlashRepo[(idx + 1)..];
+    }
+}

--- a/src/Wrangler.Api/Webhooks/RepoDataKind.cs
+++ b/src/Wrangler.Api/Webhooks/RepoDataKind.cs
@@ -1,0 +1,13 @@
+namespace Asm.Wrangler.Api.Webhooks;
+
+/// <summary>
+/// Categories of GitHub data tracked by the version sidecar.
+/// Each category has its own version stamp per (owner, repo).
+/// </summary>
+public enum RepoDataKind
+{
+    Workflows,
+    WorkflowRuns,
+    Pulls,
+    Checks,
+}

--- a/src/Wrangler.Api/Webhooks/RepoVersionService.cs
+++ b/src/Wrangler.Api/Webhooks/RepoVersionService.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Asm.Wrangler.Api.Webhooks;
+
+internal class RepoVersionService(IDistributedCache cache) : IRepoVersionService
+{
+    private static string KindToken(RepoDataKind kind) => kind switch
+    {
+        RepoDataKind.Workflows => "workflows",
+        RepoDataKind.WorkflowRuns => "workflow_runs",
+        RepoDataKind.Pulls => "pulls",
+        RepoDataKind.Checks => "checks",
+        _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+    };
+
+    private static string Key(string owner, string repo, RepoDataKind kind) => $"gh:ver:{owner}/{repo}:{KindToken(kind)}";
+
+    public async Task<long> GetVersionAsync(string owner, string repo, RepoDataKind kind, CancellationToken cancellationToken)
+    {
+        var value = await cache.GetStringAsync(Key(owner, repo, kind), cancellationToken);
+        return Int64.TryParse(value, out var version) ? version : 0L;
+    }
+
+    public Task BumpAsync(string owner, string repo, RepoDataKind kind, CancellationToken cancellationToken)
+    {
+        // Monotonic-enough: two simultaneous bumps both write the current
+        // milliseconds; whichever wins is still strictly greater than what
+        // came before, which is all the cache key needs.
+        var stamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+        return cache.SetStringAsync(Key(owner, repo, kind), stamp, cancellationToken);
+    }
+}

--- a/src/Wrangler.Api/Wrangler.Api.csproj
+++ b/src/Wrangler.Api/Wrangler.Api.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="Octokit.GraphQL" Version="0.4.0-beta" />
+    <PackageReference Include="Octokit.Webhooks.AspNetCore" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Wrangler.App/src/App.tsx
+++ b/src/Wrangler.App/src/App.tsx
@@ -2,11 +2,14 @@ import { Outlet, useRouterState } from '@tanstack/react-router'
 import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { Notifications } from '@andrewmclachlan/moo-ds'
 import { Layout } from './layout/Layout'
+import { useGitHubEventStream } from './hooks/useGitHubEventStream'
 
 function App() {
 
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const isHome = pathname === "/";
+
+  useGitHubEventStream(!isHome);
 
   if (isHome) {
     return (

--- a/src/Wrangler.App/src/hooks/useGitHubEventStream.ts
+++ b/src/Wrangler.App/src/hooks/useGitHubEventStream.ts
@@ -1,0 +1,67 @@
+import { useEffect } from "react";
+import { useQueryClient, type QueryKey } from "@tanstack/react-query";
+
+interface GitHubEvent {
+  type: string;
+  owner: string;
+  repo: string;
+  workflowId?: number;
+  runId?: number;
+  pullRequestNumber?: number;
+  deliveryId?: string;
+}
+
+const queryKeyPrefixesFor = (evt: GitHubEvent): QueryKey[] => {
+  switch (evt.type) {
+    case "workflow_run":
+    case "check_run":
+    case "check_suite":
+      return [["getWorkflows"], ["getWorkflowRuns", evt.owner, evt.repo]];
+    case "pull_request":
+      return [["pullRequests"]];
+    default:
+      return [];
+  }
+};
+
+const matchesPrefix = (queryKey: QueryKey, prefix: QueryKey): boolean => {
+  if (prefix.length > queryKey.length) return false;
+  for (let i = 0; i < prefix.length; i++) {
+    if (queryKey[i] !== prefix[i]) return false;
+  }
+  return true;
+};
+
+export const useGitHubEventStream = (enabled: boolean = true) => {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const source = new EventSource("/api/events/stream", { withCredentials: true });
+
+    const handle = (rawEvent: MessageEvent) => {
+      let parsed: GitHubEvent;
+      try {
+        parsed = JSON.parse(rawEvent.data);
+      } catch {
+        return;
+      }
+
+      const prefixes = queryKeyPrefixesFor(parsed);
+      for (const prefix of prefixes) {
+        queryClient.invalidateQueries({
+          predicate: (query) => matchesPrefix(query.queryKey, prefix),
+        });
+      }
+    };
+
+    for (const type of ["workflow_run", "check_run", "check_suite", "pull_request"]) {
+      source.addEventListener(type, handle);
+    }
+
+    return () => {
+      source.close();
+    };
+  }, [enabled, queryClient]);
+};

--- a/src/Wrangler.App/src/routes/dashboard/-hooks/useWorkflowRuns.ts
+++ b/src/Wrangler.App/src/routes/dashboard/-hooks/useWorkflowRuns.ts
@@ -18,7 +18,8 @@ export const useWorkflowRuns = (owner: string, repo: string, workflowId: number,
       return result.data;
     },
     refetchOnWindowFocus: false,
-    refetchInterval: 1000 * 60 * 2, // 2 minutes
-    staleTime: 1000 * 60, // 1 minute
+    // SSE drives freshness; polling is a safety net for missed events.
+    refetchInterval: 1000 * 60 * 10, // 10 minutes
+    staleTime: 1000 * 60 * 10,
   });
 }

--- a/src/Wrangler.App/src/routes/pull-requests/-hooks/usePullRequests.ts
+++ b/src/Wrangler.App/src/routes/pull-requests/-hooks/usePullRequests.ts
@@ -22,7 +22,8 @@ export const usePullRequests = () => {
       return result.data;
     },
     enabled: repositories.length > 0 && authors.length > 0,
-    refetchInterval: 2 * 60 * 1000,
-    staleTime: 60 * 1000,
+    // SSE drives freshness; polling is a safety net for missed events.
+    refetchInterval: 10 * 60 * 1000,
+    staleTime: 10 * 60 * 1000,
   });
 }

--- a/tests/Wrangler.Tests/EndpointKindMapperTests.cs
+++ b/tests/Wrangler.Tests/EndpointKindMapperTests.cs
@@ -1,0 +1,53 @@
+using Asm.Wrangler.Api.Webhooks;
+
+namespace Asm.Wrangler.Tests;
+
+public class EndpointKindMapperTests
+{
+    [Theory]
+    [InlineData("/repos/octocat/Hello-World/actions/workflows", "octocat", "Hello-World", RepoDataKind.Workflows)]
+    [InlineData("/repos/octocat/Hello-World/actions/workflows/12345", "octocat", "Hello-World", RepoDataKind.Workflows)]
+    [InlineData("/repos/octocat/Hello-World/actions/workflows/12345/runs", "octocat", "Hello-World", RepoDataKind.WorkflowRuns)]
+    [InlineData("/repos/octocat/Hello-World/actions/runs", "octocat", "Hello-World", RepoDataKind.WorkflowRuns)]
+    [InlineData("/repos/octocat/Hello-World/actions/runs/9999", "octocat", "Hello-World", RepoDataKind.WorkflowRuns)]
+    [InlineData("/repos/octocat/Hello-World/pulls", "octocat", "Hello-World", RepoDataKind.Pulls)]
+    [InlineData("/repos/octocat/Hello-World/pulls/42", "octocat", "Hello-World", RepoDataKind.Pulls)]
+    [InlineData("/repos/octocat/Hello-World/check-runs", "octocat", "Hello-World", RepoDataKind.Checks)]
+    [InlineData("/repos/octocat/Hello-World/check-suites", "octocat", "Hello-World", RepoDataKind.Checks)]
+    [InlineData("/repos/octocat/Hello-World/commits/abc123/check-runs", "octocat", "Hello-World", RepoDataKind.Checks)]
+    [InlineData("/repos/octocat/Hello-World/commits/abc123/status", "octocat", "Hello-World", RepoDataKind.Checks)]
+    public void MapsKnownEndpoints(string path, string expectedOwner, string expectedRepo, RepoDataKind expectedKind)
+    {
+        Assert.True(EndpointKindMapper.TryMap(path, out var owner, out var repo, out var kind));
+        Assert.Equal(expectedOwner, owner);
+        Assert.Equal(expectedRepo, repo);
+        Assert.Equal(expectedKind, kind);
+    }
+
+    [Theory]
+    [InlineData("/user/repos")]
+    [InlineData("/repos/octocat/Hello-World")]                          // bare repo, no tail
+    [InlineData("/repos/octocat/Hello-World/contents/README.md")]       // unrelated tail
+    [InlineData("/repos/octocat/Hello-World/commits/abc123")]           // commit details (not status/checks)
+    [InlineData("")]
+    public void DoesNotMapUnknownEndpoints(string path)
+    {
+        Assert.False(EndpointKindMapper.TryMap(path, out _, out _, out _));
+    }
+
+    [Fact]
+    public void StripsQueryString()
+    {
+        Assert.True(EndpointKindMapper.TryMap("/repos/octocat/Hello-World/pulls?state=open&per_page=100", out var owner, out var repo, out var kind));
+        Assert.Equal("octocat", owner);
+        Assert.Equal("Hello-World", repo);
+        Assert.Equal(RepoDataKind.Pulls, kind);
+    }
+
+    [Fact]
+    public void IsCaseInsensitiveOnFixedSegments()
+    {
+        Assert.True(EndpointKindMapper.TryMap("/REPOS/octocat/Hello-World/PULLS", out _, out _, out var kind));
+        Assert.Equal(RepoDataKind.Pulls, kind);
+    }
+}

--- a/tests/Wrangler.Tests/InstallationRegistryTests.cs
+++ b/tests/Wrangler.Tests/InstallationRegistryTests.cs
@@ -1,0 +1,99 @@
+using Asm.Wrangler.Api.Webhooks;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+
+namespace Asm.Wrangler.Tests;
+
+public class InstallationRegistryTests
+{
+    private static (InstallationRegistry registry, IDistributedCache cache) CreateRegistry()
+    {
+        var cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        return (new InstallationRegistry(cache), cache);
+    }
+
+    private static InstallationInfo SampleInfo() => new()
+    {
+        Account = "octocat",
+        AccountId = 1,
+        Type = "User",
+    };
+
+    [Fact]
+    public async Task SaveInstallation_StoresReverseLookup()
+    {
+        var (registry, _) = CreateRegistry();
+
+        await registry.SaveInstallationAsync(42, SampleInfo(), ["octocat/spoon", "octocat/fork"], CancellationToken.None);
+
+        Assert.Equal(42, await registry.GetInstallationIdForRepoAsync("octocat", "spoon", CancellationToken.None));
+        Assert.Equal(42, await registry.GetInstallationIdForRepoAsync("octocat", "fork", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RemoveInstallation_ClearsReverseLookup()
+    {
+        var (registry, _) = CreateRegistry();
+
+        await registry.SaveInstallationAsync(42, SampleInfo(), ["octocat/spoon"], CancellationToken.None);
+        await registry.RemoveInstallationAsync(42, CancellationToken.None);
+
+        Assert.Null(await registry.GetInstallationIdForRepoAsync("octocat", "spoon", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task AddRepositories_UnionsWithExisting()
+    {
+        var (registry, _) = CreateRegistry();
+
+        await registry.SaveInstallationAsync(42, SampleInfo(), ["octocat/spoon"], CancellationToken.None);
+        await registry.AddRepositoriesAsync(42, ["octocat/fork", "octocat/spoon"], CancellationToken.None);
+
+        Assert.Equal(42, await registry.GetInstallationIdForRepoAsync("octocat", "spoon", CancellationToken.None));
+        Assert.Equal(42, await registry.GetInstallationIdForRepoAsync("octocat", "fork", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RemoveRepositories_DropsReverseLookupForRemovedOnly()
+    {
+        var (registry, _) = CreateRegistry();
+
+        await registry.SaveInstallationAsync(42, SampleInfo(), ["octocat/spoon", "octocat/fork"], CancellationToken.None);
+        await registry.RemoveRepositoriesAsync(42, ["octocat/fork"], CancellationToken.None);
+
+        Assert.Equal(42, await registry.GetInstallationIdForRepoAsync("octocat", "spoon", CancellationToken.None));
+        Assert.Null(await registry.GetInstallationIdForRepoAsync("octocat", "fork", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task TryClaimDelivery_FirstCallSucceedsDuplicateFails()
+    {
+        var (registry, _) = CreateRegistry();
+
+        Assert.True(await registry.TryClaimDeliveryAsync("delivery-1", CancellationToken.None));
+        Assert.False(await registry.TryClaimDeliveryAsync("delivery-1", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task TryClaimDelivery_DifferentIdsAreIndependent()
+    {
+        var (registry, _) = CreateRegistry();
+
+        Assert.True(await registry.TryClaimDeliveryAsync("a", CancellationToken.None));
+        Assert.True(await registry.TryClaimDeliveryAsync("b", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SetSuspended_MutatesStoredInfo()
+    {
+        var (registry, cache) = CreateRegistry();
+
+        await registry.SaveInstallationAsync(42, SampleInfo(), [], CancellationToken.None);
+        await registry.SetSuspendedAsync(42, suspended: true, CancellationToken.None);
+
+        var json = await cache.GetStringAsync("gh:install:42", CancellationToken.None);
+        Assert.NotNull(json);
+        Assert.Contains("\"SuspendedAt\":", json);
+    }
+}


### PR DESCRIPTION
## Summary

Implements GitHub webhook support (issue #93) in three phases so the dashboard reacts to changes within seconds instead of waiting for the 2-minute poll.

- **Phase 1** — `/webhooks/github` receiver via `Octokit.Webhooks.AspNetCore`, HMAC-verified and deduped by `X-GitHub-Delivery` for 10 minutes. `InstallationRegistry` tracks installations and their repositories from `installation` / `installation_repositories` events.
- **Phase 2** — per-(owner, repo, kind) freshness stamps stored in the distributed cache. The Octokit response cache folds the current stamp into its keys, so a webhook-driven bump orphans previous entries without needing to walk Redis. `EndpointKindMapper` translates `/repos/{o}/{r}/...` paths into a `(workflows | workflow_runs | pulls | checks)` bucket.
- **Phase 3** — `EventBroadcaster` (channel-per-subscriber, drop-oldest at 64 items) fans webhook events out to `/api/events/stream`, which streams SSE with 25 s heartbeats. The frontend's `useGitHubEventStream` hook mounts in `App.tsx`, invalidates React Query keys by predicate match, and the existing polling has been relaxed from 2 min to 10 min as a safety net.

Phase 4 (installation UX) was scoped out: with GitHub App auth, user-to-server tokens are already gated by installation, so the originally proposed "uncovered repos" banner doesn't apply.

Tested end-to-end via smee.io: a real `workflow_run` delivery flowed from GitHub → smee → API (200) → SSE frame → React Query invalidation → dashboard refresh.

Closes #93.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 70 tests pass (incl. new `InstallationRegistryTests` and `EndpointKindMapperTests`)
- [x] `npm run build` clean on `src/Wrangler.App`
- [x] End-to-end: ping verified 204; `pull_request` / `workflow_run` delivered, processed, broadcast, and invalidated React Query as expected
- [ ] Deploy to staging slot, confirm Azure App Service doesn't buffer the SSE response
- [ ] Confirm webhook delivery time stays low on real workload (no rate-limit pressure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)