### PR TITLE
Harden SSE handler against Azure App Service buffering

### DIFF
--- a/src/Wrangler.Api/Handlers/EventStreamHandler.cs
+++ b/src/Wrangler.Api/Handlers/EventStreamHandler.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Asm.Wrangler.Api.Webhooks;
+using Microsoft.AspNetCore.Http.Features;
 
 namespace Asm.Wrangler.Api.Handlers;
 
@@ -13,8 +14,15 @@ public static class EventStreamHandler
 
     public static async Task Handle(HttpContext http, IEventBroadcaster broadcaster, CancellationToken cancellationToken)
     {
+        // Kestrel-level buffering defence; X-Accel-Buffering only signals the
+        // reverse proxy (App Service front-end / nginx) and won't stop Kestrel
+        // from holding writes itself.
+        http.Features.Get<IHttpResponseBodyFeature>()?.DisableBuffering();
+
         http.Response.Headers["Content-Type"] = "text/event-stream";
-        http.Response.Headers["Cache-Control"] = "no-cache";
+        // no-transform asks intermediaries (App Service front door, any CDN) not
+        // to recompress or rechunk the stream.
+        http.Response.Headers["Cache-Control"] = "no-cache, no-transform";
         http.Response.Headers["X-Accel-Buffering"] = "no";
         http.Response.Headers.Connection = "keep-alive";
 


### PR DESCRIPTION
## Summary

Follow-up to #131. Two defensive changes in `EventStreamHandler` recommended by the [Microsoft Learn Q&A on SSE on App Service](https://learn.microsoft.com/en-us/answers/questions/5573038/issues-with-sse-(server-side-events)-on-azure-app):

- Call `IHttpResponseBodyFeature.DisableBuffering()` so Kestrel itself doesn't hold writes; the `X-Accel-Buffering` header only signals the reverse proxy.
- Add `no-transform` to `Cache-Control` so intermediaries (App Service front-end, any CDN) don't recompress or re-chunk the stream.

Also worth doing outside the codebase before the next staging deploy:
- Set the App Service application setting `WEBSITE_DISABLE_HTTP_COMPRESSION=1`.
- Confirm Application Insights request/response body logging is off (it's off by default; only matters if it's been turned on for debugging).

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 70 tests still pass
- [ ] Deploy to staging slot; open `/api/events/stream` from the browser; trigger a webhook; confirm SSE frames flow on the *second* and subsequent connections (the article's specific failure mode is "first request works, subsequent fail")

🤖 Generated with [Claude Code](https://claude.com/claude-code)