### PR TITLE
Remember the user's preferred dashboard view (#74)

### DIFF
--- a/src/Wrangler.App/src/routes/dashboard.tsx
+++ b/src/Wrangler.App/src/routes/dashboard.tsx
@@ -6,12 +6,14 @@ import { Dashboard as b } from "@andrewmclachlan/moo-icons";
 import { Dashboard, NestedList, List } from "../assets";
 import { useSelectedRepositories } from "./settings/-hooks/useSelectedRepositories";
 import { NoRepositories } from "../components/NoRepositories";
+import { useDashboardView } from "./dashboard/-hooks/useDashboardView";
 
 
 export const Route = createFileRoute("/dashboard")({
     component: () => {
         const { data: selectedRepositories } = useSelectedRepositories();
         const hasRepos = selectedRepositories && selectedRepositories.length > 0;
+        const [, setView] = useDashboardView();
 
         return (
             <DashboardProvider>
@@ -20,9 +22,9 @@ export const Route = createFileRoute("/dashboard")({
                         <section className="controls">
                             <Filters />
                             <div className="views">
-                                <Link to="/dashboard"><Icon icon={Dashboard} title="Card view" /></Link>
-                                <Link to="/dashboard/nested"><Icon icon={NestedList} title="Nested list view" /></Link>
-                                <Link to="/dashboard/list"><Icon icon={List} title="List view" /></Link>
+                                <Link to="/dashboard" onClick={() => setView("overview")}><Icon icon={Dashboard} title="Card view" /></Link>
+                                <Link to="/dashboard/nested" onClick={() => setView("nested")}><Icon icon={NestedList} title="Nested list view" /></Link>
+                                <Link to="/dashboard/list" onClick={() => setView("list")}><Icon icon={List} title="List view" /></Link>
                             </div>
                         </section>
                     )}

--- a/src/Wrangler.App/src/routes/dashboard/-hooks/useDashboardView.ts
+++ b/src/Wrangler.App/src/routes/dashboard/-hooks/useDashboardView.ts
@@ -1,0 +1,7 @@
+import { useLocalStorage } from "@andrewmclachlan/moo-ds";
+
+export type DashboardView = "overview" | "nested" | "list";
+
+export const DASHBOARD_VIEW_STORAGE_KEY = "dashboardView";
+
+export const useDashboardView = () => useLocalStorage<DashboardView>(DASHBOARD_VIEW_STORAGE_KEY, "overview");

--- a/src/Wrangler.App/src/routes/dashboard/index.tsx
+++ b/src/Wrangler.App/src/routes/dashboard/index.tsx
@@ -1,6 +1,22 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 import { Overview } from "./-components/overview/Overview";
+import { DASHBOARD_VIEW_STORAGE_KEY } from "./-hooks/useDashboardView";
 
 export const Route = createFileRoute("/dashboard/")({
+  beforeLoad: () => {
+    // moo-ds useLocalStorage JSON-encodes values, so the literal stored
+    // string is e.g. "\"nested\"" — parse before comparing.
+    const raw = typeof window !== "undefined" ? window.localStorage.getItem(DASHBOARD_VIEW_STORAGE_KEY) : null;
+    if (!raw) return;
+    try {
+      const view = JSON.parse(raw);
+      if (view === "nested") throw redirect({ to: "/dashboard/nested" });
+      if (view === "list") throw redirect({ to: "/dashboard/list" });
+    } catch (err) {
+      // Re-throw redirects; swallow JSON parse errors so a corrupt entry
+      // can't deadlock the dashboard.
+      if (err && typeof err === "object" && "to" in err) throw err;
+    }
+  },
   component: Overview,
 });


### PR DESCRIPTION
## Summary

Persists the chosen dashboard view (overview / nested / list) across sessions:

- New `useDashboardView` hook (moo-ds `useLocalStorage` under the hood) records the chosen view when a view icon is clicked.
- `/dashboard/` index route's `beforeLoad` reads the saved value and redirects to `/dashboard/nested` or `/dashboard/list` when appropriate, otherwise renders the overview.

Closes #74.

## Test plan

- [x] `npm run build` clean
- [ ] In the running app, switch to "Nested list view" — refresh — confirm we land back on the nested view
- [ ] Switch to "List view" — refresh — confirm list view
- [ ] Switch back to "Card view" — refresh — confirm card view
- [ ] Clear `localStorage.dashboardView` — refresh — default to card view

🤖 Generated with [Claude Code](https://claude.com/claude-code)