### PR TITLE
Add user menu with logout (#95)

### DIFF
--- a/src/Wrangler.Api/Handlers/CallbackHandler.cs
+++ b/src/Wrangler.Api/Handlers/CallbackHandler.cs
@@ -74,10 +74,12 @@ public static class CallbackHandler
 
         var user = JsonSerializer.Deserialize<JsonElement>(userJson);
         var login = user.GetProperty("login").GetString();
+        var avatarUrl = user.TryGetProperty("avatar_url", out var avatarProp) ? avatarProp.GetString() : null;
 
         // Store in session
         http.Session.SetString("github_access_token", accessToken);
         http.Session.SetString("github_user", login ?? "unknown");
+        if (!String.IsNullOrEmpty(avatarUrl)) http.Session.SetString("github_avatar_url", avatarUrl);
 
         return Results.Redirect("/dashboard");
     }

--- a/src/Wrangler.Api/Handlers/LogoutHandler.cs
+++ b/src/Wrangler.Api/Handlers/LogoutHandler.cs
@@ -1,0 +1,28 @@
+namespace Asm.Wrangler.Api.Handlers;
+
+/// <summary>
+/// Ends the current session, clearing the GitHub access token from
+/// server-side state and dropping the session cookie on the client.
+/// </summary>
+public static class LogoutHandler
+{
+    public static async Task<IResult> Handle(HttpContext http)
+    {
+        // Remove all server-side session keys (github_access_token, github_user,
+        // oauth_state, etc.). Any per-user cache entries keyed off the token's
+        // hash are now orphaned and will fall off their 30-min sliding TTL.
+        http.Session.Clear();
+        await http.Session.CommitAsync();
+
+        // Tell the browser to discard the session cookie so the next request
+        // starts fresh.
+        http.Response.Cookies.Delete(".GitHub.Session", new CookieOptions
+        {
+            Path = "/",
+            Secure = true,
+            SameSite = SameSiteMode.Lax,
+        });
+
+        return Results.NoContent();
+    }
+}

--- a/src/Wrangler.Api/Handlers/MeHandler.cs
+++ b/src/Wrangler.Api/Handlers/MeHandler.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Asm.Wrangler.Api.Handlers;
+
+/// <summary>
+/// Identity of the currently authenticated GitHub user.
+/// </summary>
+public record CurrentUserModel
+{
+    /// <summary>The user's GitHub login (username).</summary>
+    public required string Login { get; init; }
+}
+
+/// <summary>
+/// Returns the current authenticated user, if any.
+/// </summary>
+public static class MeHandler
+{
+    public static Results<Ok<CurrentUserModel>, UnauthorizedHttpResult> Handle(HttpContext http)
+    {
+        var login = http.Session.GetString("github_user");
+        if (String.IsNullOrEmpty(login)) return TypedResults.Unauthorized();
+        return TypedResults.Ok(new CurrentUserModel { Login = login });
+    }
+}

--- a/src/Wrangler.Api/Handlers/MeHandler.cs
+++ b/src/Wrangler.Api/Handlers/MeHandler.cs
@@ -9,6 +9,9 @@ public record CurrentUserModel
 {
     /// <summary>The user's GitHub login (username).</summary>
     public required string Login { get; init; }
+
+    /// <summary>The URL of the user's GitHub avatar image.</summary>
+    public string? AvatarUrl { get; init; }
 }
 
 /// <summary>
@@ -20,6 +23,10 @@ public static class MeHandler
     {
         var login = http.Session.GetString("github_user");
         if (String.IsNullOrEmpty(login)) return TypedResults.Unauthorized();
-        return TypedResults.Ok(new CurrentUserModel { Login = login });
+        return TypedResults.Ok(new CurrentUserModel
+        {
+            Login = login,
+            AvatarUrl = http.Session.GetString("github_avatar_url"),
+        });
     }
 }

--- a/src/Wrangler.Api/Program.cs
+++ b/src/Wrangler.Api/Program.cs
@@ -221,6 +221,7 @@ static void AddApp(WebApplication app)
 
     app.MapGet("/callback/github", CallbackHandler.Handle).ExcludeFromDescription();
     app.MapGet("/login/github", LoginHandler.Handle).ExcludeFromDescription();
+    app.MapPost("/logout", (Delegate)LogoutHandler.Handle).ExcludeFromDescription().DisableAntiforgery().AllowAnonymous();
 
     var webhookSecret = app.Configuration.GetSection(GitHubAppOptions.SectionName)[nameof(GitHubAppOptions.WebhookSecret)];
     app.MapGitHubWebhooks("/webhooks/github", webhookSecret).AllowAnonymous().ExcludeFromDescription().DisableAntiforgery();
@@ -245,6 +246,7 @@ static void AddApp(WebApplication app)
 
     var api = app.MapGroup(ApiPrefix);
 
+    api.MapGet("me", MeHandler.Handle);
     api.MapGet("repositories", RepositoriesHandler.Handle);
     api.MapGet("repositories/grouped", GroupedRepositoriesHandler.Handle);
     api.MapPost("workflows", WorkflowsHandler.Handle).DisableAntiforgery();

--- a/src/Wrangler.Api/openapi-v1.json
+++ b/src/Wrangler.Api/openapi-v1.json
@@ -5,6 +5,25 @@
     "version": "1.0.0"
   },
   "paths": {
+    "/me": {
+      "get": {
+        "tags": [
+          "MeHandler"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CurrentUserModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/repositories": {
       "get": {
         "tags": [
@@ -384,6 +403,17 @@
           "Failure",
           "Unknown"
         ]
+      },
+      "CurrentUserModel": {
+        "required": [
+          "login"
+        ],
+        "type": "object",
+        "properties": {
+          "login": {
+            "type": "string"
+          }
+        }
       },
       "DependabotSecurityUpdates": {
         "type": "object",
@@ -1463,6 +1493,9 @@
     }
   },
   "tags": [
+    {
+      "name": "MeHandler"
+    },
     {
       "name": "RepositoriesHandler"
     },

--- a/src/Wrangler.App/src/css/components.css
+++ b/src/Wrangler.App/src/css/components.css
@@ -5,6 +5,7 @@
 @import "./components/status-indicator.css";
 @import "./components/spinner.css";
 @import "./components/no-repositories.css";
+@import "./components/user-menu.css";
 
 /* Dashboard views */
 @import "./components/overview/overview.css";

--- a/src/Wrangler.App/src/css/components/user-menu.css
+++ b/src/Wrangler.App/src/css/components/user-menu.css
@@ -1,7 +1,6 @@
 @scope (.user-menu) {
   :scope {
     position: relative;
-    margin-left: 0.75rem;
   }
 
   .user-menu-toggle {

--- a/src/Wrangler.App/src/css/components/user-menu.css
+++ b/src/Wrangler.App/src/css/components/user-menu.css
@@ -7,21 +7,35 @@
   .user-menu-toggle {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    justify-content: center;
     background: transparent;
-    border: 1px solid rgba(255, 255, 255, 0.08);
-    color: rgba(255, 255, 255, 0.75);
-    padding: 0.25rem 0.625rem;
-    border-radius: 6px;
+    border: 1px solid transparent;
+    padding: 0;
+    border-radius: 50%;
     cursor: pointer;
-    font-size: 0.875rem;
-    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    transition: border-color 0.15s, box-shadow 0.15s;
 
     &:hover, &[aria-expanded="true"] {
-      background: rgba(255, 255, 255, 0.06);
-      color: rgba(255, 255, 255, 0.95);
-      border-color: rgba(255, 255, 255, 0.15);
+      border-color: rgba(255, 255, 255, 0.25);
+      box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.06);
     }
+  }
+
+  .user-menu-avatar {
+    display: block;
+    width: 1.875rem;
+    height: 1.875rem;
+    border-radius: 50%;
+    object-fit: cover;
+  }
+
+  .user-menu-avatar-fallback {
+    background: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.85rem;
+    font-weight: 500;
+    line-height: 1.875rem;
+    text-align: center;
   }
 
   .user-menu-dropdown {

--- a/src/Wrangler.App/src/css/components/user-menu.css
+++ b/src/Wrangler.App/src/css/components/user-menu.css
@@ -1,0 +1,57 @@
+@scope (.user-menu) {
+  :scope {
+    position: relative;
+    margin-left: 0.75rem;
+  }
+
+  .user-menu-toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.75);
+    padding: 0.25rem 0.625rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+
+    &:hover, &[aria-expanded="true"] {
+      background: rgba(255, 255, 255, 0.06);
+      color: rgba(255, 255, 255, 0.95);
+      border-color: rgba(255, 255, 255, 0.15);
+    }
+  }
+
+  .user-menu-dropdown {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    right: 0;
+    min-width: 10rem;
+    list-style: none;
+    padding: 0.25rem;
+    margin: 0;
+    background: #14141c;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 6px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+    z-index: 100;
+
+    li button {
+      width: 100%;
+      text-align: left;
+      background: transparent;
+      border: none;
+      color: rgba(255, 255, 255, 0.85);
+      padding: 0.5rem 0.75rem;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.875rem;
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.06);
+      }
+    }
+  }
+}

--- a/src/Wrangler.App/src/css/layout.css
+++ b/src/Wrangler.App/src/css/layout.css
@@ -25,7 +25,7 @@
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: 0.5rem;
+    gap: 0.875rem;
 }
 
 .top-nav {
@@ -34,7 +34,7 @@
         margin: 0;
         padding: 0;
         display: flex;
-        gap: 0.25rem;
+        gap: 0.5rem;
         flex-direction: row;
         align-items: center;
 
@@ -42,8 +42,8 @@
             display: flex;
             align-items: center;
             justify-content: center;
-            width: 2.25rem;
-            height: 2.25rem;
+            width: 1.875rem;
+            height: 1.875rem;
             border-radius: 6px;
             transition: background 0.15s, color 0.15s;
             color: rgba(255, 255, 255, 0.45);

--- a/src/Wrangler.App/src/css/layout.css
+++ b/src/Wrangler.App/src/css/layout.css
@@ -21,6 +21,13 @@
     background: rgba(0, 0, 0, 0.3);
 }
 
+.header-end {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+}
+
 .top-nav {
     ul {
         list-style: none;

--- a/src/Wrangler.App/src/hooks/useCurrentUser.ts
+++ b/src/Wrangler.App/src/hooks/useCurrentUser.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+
+export interface CurrentUser {
+  login: string;
+}
+
+export const useCurrentUser = () =>
+  useQuery<CurrentUser | null>({
+    queryKey: ["me"],
+    queryFn: async () => {
+      const res = await fetch("/api/me", { credentials: "include" });
+      if (res.status === 401) return null;
+      if (!res.ok) throw new Error(`Failed to fetch current user: ${res.status}`);
+      return res.json();
+    },
+    retry: false,
+    staleTime: 5 * 60 * 1000,
+  });

--- a/src/Wrangler.App/src/hooks/useCurrentUser.ts
+++ b/src/Wrangler.App/src/hooks/useCurrentUser.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 
 export interface CurrentUser {
   login: string;
+  avatarUrl?: string;
 }
 
 export const useCurrentUser = () =>

--- a/src/Wrangler.App/src/layout/Layout.tsx
+++ b/src/Wrangler.App/src/layout/Layout.tsx
@@ -17,14 +17,16 @@ export const Layout: React.FC<PropsWithChildren> = ({ children }) => {
             Wrangler CI
           </Link>
         </h1>
-        <nav className="top-nav">
-          <ul>
-            <li><Link to="/dashboard"><Icon icon={Dashboard} /></Link></li>
-            <li><Link to="/pull-requests"><Icon icon={PullRequest} className="pr-icon" /></Link></li>
-            <li><Link to="/settings"><Icon icon={Cog} /></Link></li>
-          </ul>
-        </nav>
-        <UserMenu />
+        <div className="header-end">
+          <nav className="top-nav">
+            <ul>
+              <li><Link to="/dashboard"><Icon icon={Dashboard} /></Link></li>
+              <li><Link to="/pull-requests"><Icon icon={PullRequest} className="pr-icon" /></Link></li>
+              <li><Link to="/settings"><Icon icon={Cog} /></Link></li>
+            </ul>
+          </nav>
+          <UserMenu />
+        </div>
       </header>
       <main>
         {children}

--- a/src/Wrangler.App/src/layout/Layout.tsx
+++ b/src/Wrangler.App/src/layout/Layout.tsx
@@ -2,6 +2,7 @@ import { Icon } from "@andrewmclachlan/moo-ds";
 import { Cog, Dashboard, PullRequest } from "@andrewmclachlan/moo-icons";
 import { Link } from "@tanstack/react-router";
 import type { PropsWithChildren } from "react";
+import { UserMenu } from "./UserMenu";
 
 export const Layout: React.FC<PropsWithChildren> = ({ children }) => {
   return (
@@ -23,6 +24,7 @@ export const Layout: React.FC<PropsWithChildren> = ({ children }) => {
             <li><Link to="/settings"><Icon icon={Cog} /></Link></li>
           </ul>
         </nav>
+        <UserMenu />
       </header>
       <main>
         {children}

--- a/src/Wrangler.App/src/layout/UserMenu.tsx
+++ b/src/Wrangler.App/src/layout/UserMenu.tsx
@@ -1,6 +1,4 @@
 import { useEffect, useRef, useState } from "react";
-import { Icon } from "@andrewmclachlan/moo-ds";
-import { User } from "@andrewmclachlan/moo-icons";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCurrentUser } from "../hooks/useCurrentUser";
 
@@ -34,9 +32,12 @@ export const UserMenu = () => {
 
   return (
     <div className="user-menu" ref={containerRef}>
-      <button type="button" className="user-menu-toggle" onClick={() => setOpen((o) => !o)} aria-haspopup="menu" aria-expanded={open}>
-        <Icon icon={User} />
-        <span className="user-menu-login">{user.login}</span>
+      <button type="button" className="user-menu-toggle" onClick={() => setOpen((o) => !o)} aria-haspopup="menu" aria-expanded={open} aria-label={`Signed in as ${user.login}`}>
+        {user.avatarUrl ? (
+          <img src={user.avatarUrl} alt="" className="user-menu-avatar" />
+        ) : (
+          <span className="user-menu-avatar user-menu-avatar-fallback" aria-hidden="true">{user.login.charAt(0).toUpperCase()}</span>
+        )}
       </button>
       {open && (
         <ul className="user-menu-dropdown" role="menu">

--- a/src/Wrangler.App/src/layout/UserMenu.tsx
+++ b/src/Wrangler.App/src/layout/UserMenu.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "@andrewmclachlan/moo-ds";
+import { User } from "@andrewmclachlan/moo-icons";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCurrentUser } from "../hooks/useCurrentUser";
+
+export const UserMenu = () => {
+  const { data: user } = useCurrentUser();
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  if (!user) return null;
+
+  const handleLogout = async () => {
+    try {
+      await fetch("/logout", { method: "POST", credentials: "include" });
+    } finally {
+      // Drop all cached data tied to the previous session, then send the
+      // user back to the marketing/home page.
+      queryClient.clear();
+      window.location.href = "/";
+    }
+  };
+
+  return (
+    <div className="user-menu" ref={containerRef}>
+      <button type="button" className="user-menu-toggle" onClick={() => setOpen((o) => !o)} aria-haspopup="menu" aria-expanded={open}>
+        <Icon icon={User} />
+        <span className="user-menu-login">{user.login}</span>
+      </button>
+      {open && (
+        <ul className="user-menu-dropdown" role="menu">
+          <li role="none">
+            <button type="button" role="menuitem" onClick={handleLogout}>Log out</button>
+          </li>
+        </ul>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary

Adds a header-level user menu showing the signed-in GitHub login with a small dropdown that contains a **Log out** action.

**Backend**
- `GET /api/me` — returns `{ login }` for the current session, 401 when no session.
- `POST /logout` — clears the server-side session (removes `github_access_token`, `github_user`, `oauth_state`, etc.), drops the session cookie, returns 204.

**Frontend**
- `useCurrentUser` hook (plain `fetch` against `/api/me`, no API client regen needed for this PR).
- `UserMenu` component in `layout/Layout.tsx`, with click-outside to close and dropdown roles for a11y.
- Logout clears the React Query cache and navigates to `/`.

Closes #95.

## Notes

The brief mentioned clearing "any cached information in Redis." Per-user Octokit response cache entries are keyed by SHA-512 of the access token, so once the session token is gone they're orphaned and fall off their 30-min sliding TTL. `IDistributedCache` doesn't expose enumeration, so we don't proactively walk and delete them — the natural expiry is the cleanest option without adding a direct `IConnectionMultiplexer` dependency.

## Test plan

- [x] `dotnet build` clean, all 70 tests pass
- [x] `npm run build` clean
- [ ] Run app, sign in via GitHub, confirm the username appears in the header
- [ ] Click the username → dropdown shows **Log out**
- [ ] Click **Log out** → session cookie removed, page lands on `/`, no API calls return 200 (all 401)
- [ ] Sign in again → user menu shows the same login again

🤖 Generated with [Claude Code](https://claude.com/claude-code)