### PR TITLE
Add privacy policy page (#96)

### DIFF
--- a/src/Wrangler.App/src/App.tsx
+++ b/src/Wrangler.App/src/App.tsx
@@ -7,11 +7,11 @@ import { useGitHubEventStream } from './hooks/useGitHubEventStream'
 function App() {
 
   const pathname = useRouterState({ select: (s) => s.location.pathname });
-  const isHome = pathname === "/";
+  const isStandalone = pathname === "/" || pathname === "/privacy";
 
-  useGitHubEventStream(!isHome);
+  useGitHubEventStream(!isStandalone);
 
-  if (isHome) {
+  if (isStandalone) {
     return (
       <>
         <Outlet />

--- a/src/Wrangler.App/src/routeTree.gen.ts
+++ b/src/Wrangler.App/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as DashboardRouteImport } from './routes/dashboard'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as SettingsIndexRouteImport } from './routes/settings/index'
@@ -17,6 +18,11 @@ import { Route as DashboardIndexRouteImport } from './routes/dashboard/index'
 import { Route as DashboardNestedRouteImport } from './routes/dashboard/nested'
 import { Route as DashboardListRouteImport } from './routes/dashboard/list'
 
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DashboardRoute = DashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
@@ -56,6 +62,7 @@ const DashboardListRoute = DashboardListRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardRouteWithChildren
+  '/privacy': typeof PrivacyRoute
   '/dashboard/list': typeof DashboardListRoute
   '/dashboard/nested': typeof DashboardNestedRoute
   '/dashboard/': typeof DashboardIndexRoute
@@ -64,6 +71,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/privacy': typeof PrivacyRoute
   '/dashboard/list': typeof DashboardListRoute
   '/dashboard/nested': typeof DashboardNestedRoute
   '/dashboard': typeof DashboardIndexRoute
@@ -74,6 +82,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/dashboard': typeof DashboardRouteWithChildren
+  '/privacy': typeof PrivacyRoute
   '/dashboard/list': typeof DashboardListRoute
   '/dashboard/nested': typeof DashboardNestedRoute
   '/dashboard/': typeof DashboardIndexRoute
@@ -85,6 +94,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/dashboard'
+    | '/privacy'
     | '/dashboard/list'
     | '/dashboard/nested'
     | '/dashboard/'
@@ -93,6 +103,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/privacy'
     | '/dashboard/list'
     | '/dashboard/nested'
     | '/dashboard'
@@ -102,6 +113,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/dashboard'
+    | '/privacy'
     | '/dashboard/list'
     | '/dashboard/nested'
     | '/dashboard/'
@@ -112,12 +124,20 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   DashboardRoute: typeof DashboardRouteWithChildren
+  PrivacyRoute: typeof PrivacyRoute
   PullRequestsIndexRoute: typeof PullRequestsIndexRoute
   SettingsIndexRoute: typeof SettingsIndexRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/dashboard': {
       id: '/dashboard'
       path: '/dashboard'
@@ -189,6 +209,7 @@ const DashboardRouteWithChildren = DashboardRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   DashboardRoute: DashboardRouteWithChildren,
+  PrivacyRoute: PrivacyRoute,
   PullRequestsIndexRoute: PullRequestsIndexRoute,
   SettingsIndexRoute: SettingsIndexRoute,
 }

--- a/src/Wrangler.App/src/routes/-components/Home.tsx
+++ b/src/Wrangler.App/src/routes/-components/Home.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { Link } from "@tanstack/react-router";
 import "./home.css";
 
 const GitHubIcon = () => (
@@ -205,6 +206,9 @@ export const Home = () => (
         <img src="/logo-white.svg" alt="" />
       </div>
       <p>&copy; {new Date().getFullYear()} Wrangler CI</p>
+      <nav className="footer-nav">
+        <Link to="/privacy">Privacy</Link>
+      </nav>
     </footer>
   </div>
 );

--- a/src/Wrangler.App/src/routes/-components/Privacy.tsx
+++ b/src/Wrangler.App/src/routes/-components/Privacy.tsx
@@ -1,0 +1,87 @@
+import { Link } from "@tanstack/react-router";
+import "./privacy.css";
+
+export const Privacy = () => (
+  <div className="privacy">
+    <header className="privacy-header">
+      <Link to="/" className="privacy-brand">
+        <img src="/logo-white.svg" alt="Wrangler CI" />
+        <span>Wrangler CI</span>
+      </Link>
+    </header>
+
+    <main className="privacy-content">
+      <h1>Privacy</h1>
+      <p className="privacy-lede">
+        Wrangler CI is a dashboard for your GitHub Actions and pull requests. Here's
+        plainly what we do with your data.
+      </p>
+
+      <section>
+        <h2>What we store about you</h2>
+        <p>
+          When you sign in with GitHub, we ask GitHub for a short summary about you
+          and the repositories you've installed the Wrangler app on. To keep the
+          dashboard fast, we hold on to a copy of that information for up to
+          30 minutes after we last needed it &mdash; things like:
+        </p>
+        <ul>
+          <li>The list of repositories you can see.</li>
+          <li>Each repository's workflows and their most recent runs.</li>
+          <li>Open pull requests in those repositories.</li>
+          <li>Your GitHub login name, so we can greet you.</li>
+        </ul>
+        <p>
+          We do not collect anything you wouldn't already see when browsing GitHub
+          yourself, and we do not sell, share, or analyse your data for any other
+          purpose.
+        </p>
+      </section>
+
+      <section>
+        <h2>Why we set a cookie</h2>
+        <p>
+          When you sign in, your browser receives a single cookie named
+          <code> .GitHub.Session</code>. It only does one job: it tells Wrangler
+          who you are on each request so we can show you your dashboard and
+          nobody else's. It's marked secure and HTTP-only, which means it travels
+          only over HTTPS and isn't readable by other websites or by scripts on
+          this page.
+        </p>
+        <p>
+          We don't use cookies for advertising, analytics, or tracking you across
+          other sites.
+        </p>
+      </section>
+
+      <section>
+        <h2>What happens when you log out</h2>
+        <p>
+          Logging out tells our server to discard your session entirely. We
+          forget your GitHub access token, we drop the cookie that identified
+          you, and the cached GitHub information described above is no longer
+          tied to you &mdash; the next time it's needed it has to be fetched fresh
+          from GitHub.
+        </p>
+        <p>
+          Uninstalling the Wrangler GitHub app from your account or organisation
+          also stops the flow of new data. We never had write access to your
+          repositories beyond the actions you explicitly took in the dashboard.
+        </p>
+      </section>
+
+      <section>
+        <h2>Questions</h2>
+        <p>
+          Wrangler CI is an open-source side project. If something about how your
+          data is handled looks off, please open an issue on{" "}
+          <a href="https://github.com/AndrewMcLachlan/WranglerCI/issues" target="_blank" rel="noreferrer">GitHub</a>.
+        </p>
+      </section>
+    </main>
+
+    <footer className="privacy-footer">
+      <p>&copy; {new Date().getFullYear()} Wrangler CI</p>
+    </footer>
+  </div>
+);

--- a/src/Wrangler.App/src/routes/-components/home.css
+++ b/src/Wrangler.App/src/routes/-components/home.css
@@ -520,6 +520,16 @@
   margin: 0;
 }
 
+.footer-nav a {
+  color: var(--home-text-dim);
+  text-decoration: none;
+  letter-spacing: 0.12em;
+}
+
+.footer-nav a:hover {
+  color: var(--home-text, rgba(255, 255, 255, 0.87));
+}
+
 /* ---- Responsive ---- */
 
 @media (max-width: 900px) {

--- a/src/Wrangler.App/src/routes/-components/privacy.css
+++ b/src/Wrangler.App/src/routes/-components/privacy.css
@@ -1,0 +1,89 @@
+@scope (.privacy) {
+  :scope {
+    min-height: 100vh;
+    background: #0c0c12;
+    color: rgba(255, 255, 255, 0.85);
+    display: flex;
+    flex-direction: column;
+  }
+
+  .privacy-header {
+    padding: 1rem 2rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  }
+
+  .privacy-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: currentColor;
+    text-decoration: none;
+    font-weight: 500;
+
+    img {
+      height: 1.75rem;
+      width: 1.75rem;
+    }
+  }
+
+  .privacy-content {
+    max-width: 48rem;
+    padding: 3rem 2rem;
+    margin: 0 auto;
+    line-height: 1.6;
+    flex: 1;
+
+    h1 {
+      font-size: 2.25rem;
+      margin: 0 0 0.5rem;
+    }
+
+    h2 {
+      font-size: 1.25rem;
+      margin: 2.5rem 0 0.75rem;
+      color: rgba(255, 255, 255, 0.92);
+    }
+
+    .privacy-lede {
+      font-size: 1.125rem;
+      color: rgba(255, 255, 255, 0.7);
+      margin-bottom: 0;
+    }
+
+    p {
+      margin: 0.75rem 0;
+    }
+
+    ul {
+      margin: 0.5rem 0 0.75rem 1.25rem;
+      padding: 0;
+
+      li {
+        margin: 0.25rem 0;
+      }
+    }
+
+    code {
+      background: rgba(255, 255, 255, 0.08);
+      padding: 0.1rem 0.35rem;
+      border-radius: 3px;
+      font-size: 0.875rem;
+    }
+
+    a {
+      color: var(--primary, #d4a24e);
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  .privacy-footer {
+    padding: 1.5rem 2rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    color: rgba(255, 255, 255, 0.45);
+    font-size: 0.875rem;
+    text-align: center;
+  }
+}

--- a/src/Wrangler.App/src/routes/privacy.tsx
+++ b/src/Wrangler.App/src/routes/privacy.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Privacy } from "./-components/Privacy";
+
+export const Route = createFileRoute("/privacy")({
+  component: Privacy,
+});


### PR DESCRIPTION
## Summary

Adds a `/privacy` route with a plain-language privacy notice covering the three points called out in the issue:

- **What we store about you** — GitHub data Wrangler caches for up to 30 minutes (repo list, workflows, runs, PRs, your login). No selling, sharing, or off-purpose analytics.
- **Why we set a cookie** — the single `.GitHub.Session` cookie used for authentication; secure, HTTP-only, no tracking.
- **What logging out does** — server-side session discarded, cookie dropped, cached info no longer associated with you.

Standalone layout (no top-nav), linked from the home-page footer.

Closes #96.

## Test plan

- [x] `npm run build` clean
- [ ] Visit `/` → click "Privacy" in the footer → land on `/privacy`
- [ ] Direct-load `/privacy` without being signed in → renders fine without auth challenges
- [ ] Sign in → visit `/privacy` directly → renders fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)