### PR TITLE
Scaffold PWA support (#97)

### DIFF
--- a/src/Wrangler.Api/Program.cs
+++ b/src/Wrangler.Api/Program.cs
@@ -215,7 +215,13 @@ static void AddApp(WebApplication app)
     app.UseSession();
     app.UseAntiforgery();
     app.UseDefaultFiles();
-    app.UseStaticFiles();
+
+    // FileExtensionContentTypeProvider's defaults don't include .webmanifest,
+    // so without this it would be served as application/octet-stream and
+    // browsers would silently reject the PWA manifest.
+    var contentTypeProvider = new Microsoft.AspNetCore.StaticFiles.FileExtensionContentTypeProvider();
+    contentTypeProvider.Mappings[".webmanifest"] = "application/manifest+json";
+    app.UseStaticFiles(new StaticFileOptions { ContentTypeProvider = contentTypeProvider });
 
     app.MapOpenApi();
 

--- a/src/Wrangler.Api/openapi-v1.json
+++ b/src/Wrangler.Api/openapi-v1.json
@@ -412,6 +412,12 @@
         "properties": {
           "login": {
             "type": "string"
+          },
+          "avatarUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/src/Wrangler.App/index.html
+++ b/src/Wrangler.App/index.html
@@ -2,6 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <script>
+      // Skip the marketing home page in installed PWAs — redirect to OAuth
+      // before any bundles load so the marketing page never paints.
+      (function () {
+        if (location.pathname !== "/") return;
+        var mq = window.matchMedia && window.matchMedia("(display-mode: standalone)");
+        var standalone = (mq && mq.matches) || window.navigator.standalone === true;
+        if (standalone) location.replace("/login/github");
+      })();
+    </script>
     <link rel="icon" type="image/svg+xml" href="/logo.svg" media="(prefers-color-scheme: light)" />
     <link rel="icon" type="image/svg+xml" href="/logo-white.svg" media="(prefers-color-scheme: dark)" />
     <link rel="apple-touch-icon" href="/logo-white.svg" />

--- a/src/Wrangler.App/index.html
+++ b/src/Wrangler.App/index.html
@@ -4,8 +4,14 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" media="(prefers-color-scheme: light)" />
     <link rel="icon" type="image/svg+xml" href="/logo-white.svg" media="(prefers-color-scheme: dark)" />
+    <link rel="apple-touch-icon" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#0c0c12" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Wrangler" />
+    <meta name="description" content="GitHub Actions dashboard across all your repositories." />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet" />

--- a/src/Wrangler.App/index.html
+++ b/src/Wrangler.App/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" media="(prefers-color-scheme: light)" />
     <link rel="icon" type="image/svg+xml" href="/logo-white.svg" media="(prefers-color-scheme: dark)" />
-    <link rel="apple-touch-icon" href="/logo.svg" />
+    <link rel="apple-touch-icon" href="/logo-white.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0c0c12" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/Wrangler.App/public/manifest.webmanifest
+++ b/src/Wrangler.App/public/manifest.webmanifest
@@ -10,7 +10,7 @@
   "theme_color": "#0c0c12",
   "icons": [
     {
-      "src": "/logo.svg",
+      "src": "/logo-white.svg",
       "type": "image/svg+xml",
       "sizes": "any",
       "purpose": "any"

--- a/src/Wrangler.App/public/manifest.webmanifest
+++ b/src/Wrangler.App/public/manifest.webmanifest
@@ -1,0 +1,25 @@
+{
+  "name": "Wrangler CI",
+  "short_name": "Wrangler",
+  "description": "GitHub Actions dashboard across all your repositories.",
+  "scope": "/",
+  "start_url": "/dashboard",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#06060a",
+  "theme_color": "#0c0c12",
+  "icons": [
+    {
+      "src": "/logo.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "any"
+    },
+    {
+      "src": "/logo-white.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/src/Wrangler.App/public/sw.js
+++ b/src/Wrangler.App/public/sw.js
@@ -1,0 +1,22 @@
+// Wrangler CI service worker — scaffolding only.
+//
+// Required for the browser to treat the app as installable; deliberately
+// has no caching strategy yet so we don't serve stale assets while the
+// app is still in active development. Offline support can be layered on
+// later by adding install/activate/fetch handlers that pre-cache the
+// shell and serve cached responses on failure.
+
+self.addEventListener("install", (event) => {
+  // Take over immediately so the new SW becomes active without waiting
+  // for all tabs to close.
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+// Pass everything through to the network. Without a fetch handler at all,
+// Chrome won't treat the SW as "controlling" the page on first install,
+// which blocks the install prompt.
+self.addEventListener("fetch", () => {});

--- a/src/Wrangler.App/src/main.tsx
+++ b/src/Wrangler.App/src/main.tsx
@@ -14,8 +14,11 @@ import { Spinner } from "./components/Spinner"
 import { LinkProvider, ThemeProvider } from "@andrewmclachlan/moo-ds"
 import { NavLnk } from "./components/NavLink"
 import { client } from "./api/client.gen.ts"
+import { registerServiceWorker } from "./pwa/registerServiceWorker"
 
 library.add(faArrowUpRightFromSquare, faBarsStaggered, faChevronRight, faListUl, faLongArrowDown, faLongArrowUp, faTimesCircle);
+
+registerServiceWorker();
 
 const router = createRouter({
   routeTree,

--- a/src/Wrangler.App/src/pwa/registerServiceWorker.ts
+++ b/src/Wrangler.App/src/pwa/registerServiceWorker.ts
@@ -1,0 +1,13 @@
+// Registers the service worker that makes Wrangler installable as a PWA.
+// Only runs in production builds; the dev server doesn't ship the SW so
+// HMR isn't affected.
+export const registerServiceWorker = () => {
+  if (!import.meta.env.PROD) return;
+  if (!("serviceWorker" in navigator)) return;
+
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/sw.js").catch((err) => {
+      console.warn("Service worker registration failed", err);
+    });
+  });
+};

--- a/src/Wrangler.App/src/routes/index.ts
+++ b/src/Wrangler.App/src/routes/index.ts
@@ -1,6 +1,19 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { Home } from "./-components/Home";
 
+const isInstalledPwa = () =>
+  typeof window !== "undefined" &&
+  (window.matchMedia?.("(display-mode: standalone)").matches ||
+    (window.navigator as { standalone?: boolean }).standalone === true);
+
 export const Route = createFileRoute("/")({
+  beforeLoad: () => {
+    if (isInstalledPwa()) {
+      // Installed-app users have already chosen us; skip the marketing
+      // home and go straight to OAuth. Successful sign-in lands on
+      // /dashboard via the existing callback flow.
+      window.location.replace("/login/github");
+    }
+  },
   component: Home,
 });


### PR DESCRIPTION
## Summary

Adds the manifest, service worker, and HTML metadata needed for browsers to treat Wrangler as an installable PWA. Offline support is explicitly out of scope per the issue.

- `public/manifest.webmanifest` — name, scope, `/dashboard` start URL, standalone display, theme/background colours matching the dark UI, SVG icons.
- `public/sw.js` — minimal pass-through service worker. Required for installability; no caching strategy yet so we don't serve stale assets during active development.
- `src/pwa/registerServiceWorker.ts` — registers the SW only in production builds, so the dev server isn't blocked by stale SW caches.
- `index.html` — links the manifest, declares `apple-touch-icon` and iOS-specific PWA meta tags, updates `theme-color` to `#0c0c12` to match the manifest.

Closes #97.

## Follow-ups (deliberately not in this PR)

- Generate proper PNG icons at 192×192 and 512×512 (browsers warn about SVG-only icon sets even though the install still works).
- Build a real offline strategy (precache app shell, cache GitHub responses, etc.) — only when we're ready to commit to it.

## Test plan

- [x] `npm run build` clean; `manifest.webmanifest` and `sw.js` land in `dist/`
- [ ] Deploy; visit in Chrome → DevTools → Application → Manifest, confirm parses without errors
- [ ] Same panel → Service Workers, confirm `/sw.js` is "activated and is running"
- [ ] Chrome's address bar shows the "install" icon → install → app launches in its own window at `/dashboard`
- [ ] Lighthouse PWA audit highlights only the missing-PNG-icon warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)