### PR TITLE
Migrate DataGrid columns to the new ColumnDef field API

### DIFF
--- a/src/Wrangler.App/package-lock.json
+++ b/src/Wrangler.App/package-lock.json
@@ -2363,40 +2363,6 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
-    "node_modules/@tanstack/router-generator/node_modules/@tanstack/history": {
-      "version": "1.161.6",
-      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.161.6.tgz",
-      "integrity": "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/router-generator/node_modules/@tanstack/router-core": {
-      "version": "1.169.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.169.2.tgz",
-      "integrity": "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/history": "1.161.6",
-        "cookie-es": "^3.0.0",
-        "seroval": "^1.5.4",
-        "seroval-plugins": "^1.5.4"
-      },
-      "engines": {
-        "node": ">=20.19"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
     "node_modules/@tanstack/router-plugin": {
       "version": "1.168.6",
       "resolved": "https://registry.npmjs.org/@tanstack/router-plugin/-/router-plugin-1.168.6.tgz",
@@ -2448,40 +2414,6 @@
         "webpack": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@tanstack/router-plugin/node_modules/@tanstack/history": {
-      "version": "1.161.6",
-      "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.161.6.tgz",
-      "integrity": "sha512-NaOGLRrddszbQj9upGat6HG/4TKvXLvu+osAIgfxPYA+eIvYKv8GKDJOrY2D3/U9MRnKfMWD7bU4jeD4xmqyIg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.19"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/router-plugin/node_modules/@tanstack/router-core": {
-      "version": "1.169.2",
-      "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.169.2.tgz",
-      "integrity": "sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/history": "1.161.6",
-        "cookie-es": "^3.0.0",
-        "seroval": "^1.5.4",
-        "seroval-plugins": "^1.5.4"
-      },
-      "engines": {
-        "node": ">=20.19"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/router-utils": {

--- a/src/Wrangler.App/src/routes/dashboard/-components/list/List.tsx
+++ b/src/Wrangler.App/src/routes/dashboard/-components/list/List.tsx
@@ -1,6 +1,5 @@
-import { DataGrid, createColumnHelper } from "@andrewmclachlan/moo-ds";
+import { DataGrid, type ColumnDef } from "@andrewmclachlan/moo-ds";
 import { DateTime } from "luxon";
-import type { ColumnDef } from "@tanstack/react-table";
 import type { RepositoryModel, WorkflowModel, WorkflowRunModel } from "../../../../api";
 import { useWorkflows } from "../../-hooks/useWorkflows";
 import { Badge } from "../shared/Badge";
@@ -13,52 +12,58 @@ interface WorkflowRunItem {
 
 const formatter = new Intl.RelativeTimeFormat(navigator.language, { style: "long" });
 
-const columnHelper = createColumnHelper<WorkflowRunItem>();
-
-const columns: ColumnDef<WorkflowRunItem, any>[] = [
-  columnHelper.accessor(item => item.run.workflowStatus, {
+const columns: ColumnDef<WorkflowRunItem>[] = [
+  {
+    field: (item: WorkflowRunItem) => item.run.workflowStatus,
     id: "status",
     header: "Status",
     cell: ({ row }) => <Badge className={row.original.run.workflowStatus?.toLowerCase()}>{row.original.run.conclusion || row.original.run.status}</Badge>,
     enableSorting: true,
-  }),
-  columnHelper.accessor(item => item.workflow.name, {
+  },
+  {
+    field: (item: WorkflowRunItem) => item.workflow.name,
     id: "workflow",
     header: "Workflow",
     enableSorting: true,
-  }),
-  columnHelper.accessor(item => item.run.headBranch, {
+  },
+  {
+    field: (item: WorkflowRunItem) => item.run.headBranch,
     id: "branch",
     header: "Branch",
-    cell: ({ getValue }) => <Badge>{getValue()}</Badge>,
+    cell: ({ row }) => <Badge>{row.original.run.headBranch}</Badge>,
     enableSorting: true,
-  }),
-  columnHelper.accessor(item => item.run.updatedAt, {
+  },
+  {
+    field: (item: WorkflowRunItem) => item.run.updatedAt,
     id: "run",
     header: "Run",
-    cell: ({ getValue }) => {
-      const updatedAt = DateTime.fromISO(getValue()!);
+    cell: ({ row }) => {
+      const updatedAt = DateTime.fromISO(row.original.run.updatedAt!);
       const timeAgo = updatedAt.toRelative({ style: "long" }) || formatter.format(0, "seconds");
       return <span title={updatedAt.toFormat("yyyy-MM-dd HH:mm:ss")}>{timeAgo}</span>;
     },
     enableSorting: true,
-  }),
-  columnHelper.accessor(item => item.repo.owner, {
+  },
+  {
+    field: (item: WorkflowRunItem) => item.repo.owner,
     id: "owner",
     header: "Owner",
     enableSorting: true,
-  }),
-  columnHelper.accessor(item => item.repo.name, {
+  },
+  {
+    field: (item: WorkflowRunItem) => item.repo.name,
     id: "repository",
     header: "Repository",
     cell: ({ row }) => <a href={row.original.repo.htmlUrl!} target="_blank" rel="noopener noreferrer">{row.original.repo.name}</a>,
     enableSorting: true,
-  }),
-  columnHelper.display({
+  },
+  {
+    field: () => null,
     id: "actions",
     header: "",
     cell: ({ row }) => <a href={row.original.run.htmlUrl} target="_blank" rel="noopener noreferrer">View Run</a>,
-  }),
+    enableSorting: false,
+  },
 ];
 
 export const List = () => {

--- a/src/Wrangler.App/src/routes/pull-requests/-components/PullRequests.tsx
+++ b/src/Wrangler.App/src/routes/pull-requests/-components/PullRequests.tsx
@@ -1,9 +1,8 @@
 import { useMemo, useState } from "react";
-import { Alert, DataGrid, createColumnHelper } from "@andrewmclachlan/moo-ds";
+import { Alert, DataGrid, type ColumnDef } from "@andrewmclachlan/moo-ds";
 import { CloseBadge } from "@andrewmclachlan/moo-ds";
 import { DateTime } from "luxon";
 import { toast } from "react-toastify";
-import type { ColumnDef } from "@tanstack/react-table";
 import { usePullRequests } from "../-hooks/usePullRequests";
 import { usePrAuthors, useUpdatePrAuthors } from "../-hooks/usePrAuthors";
 import { useApprovePullRequests } from "../-hooks/useApprovePullRequests";
@@ -16,8 +15,6 @@ import type { ApprovalResult, PullRequestModel } from "../../../api";
 export const canApprove = (pr: PullRequestModel) => pr.checkStatus === "Success" && pr.mergeable !== false;
 
 const formatter = new Intl.RelativeTimeFormat(navigator.language, { style: "long" });
-
-const columnHelper = createColumnHelper<PullRequestModel>();
 
 export const PullRequests = () => {
 
@@ -95,28 +92,33 @@ export const PullRequests = () => {
     updateAuthors(authors.filter(a => a !== author));
   };
 
-  const columns: ColumnDef<PullRequestModel, any>[] = useMemo(() => [
-    columnHelper.display({
+  const columns: ColumnDef<PullRequestModel>[] = useMemo(() => [
+    {
+      field: () => null,
       id: "select",
       header: () => <input type="checkbox" checked={allSelected} onChange={toggleSelectAll} disabled={approvable.length === 0} />,
       cell: ({ row }) => <input type="checkbox" checked={selected.has(row.original.number)} onChange={() => toggleSelection(row.original)} disabled={!canApprove(row.original)} />,
       enableSorting: false,
-    }),
-    columnHelper.accessor(pr => `${pr.repositoryOwner}/${pr.repositoryName}`, {
+    },
+    {
+      field: (pr: PullRequestModel) => `${pr.repositoryOwner}/${pr.repositoryName}`,
       id: "repository",
       header: "Repository",
       enableSorting: true,
-    }),
-    columnHelper.accessor("title", {
+    },
+    {
+      field: "title",
       header: "Title",
       cell: ({ row }) => <a href={row.original.htmlUrl!} target="_blank" rel="noopener noreferrer">{row.original.title}</a>,
       enableSorting: true,
-    }),
-    columnHelper.accessor("author", {
+    },
+    {
+      field: "author",
       header: "Author",
       enableSorting: true,
-    }),
-    columnHelper.accessor("checkStatus", {
+    },
+    {
+      field: "checkStatus",
       header: "Status",
       cell: ({ row }) => (
         <>
@@ -125,16 +127,17 @@ export const PullRequests = () => {
         </>
       ),
       enableSorting: true,
-    }),
-    columnHelper.accessor("updatedAt", {
+    },
+    {
+      field: "updatedAt",
       header: "Updated",
       cell: ({ getValue }) => {
-        const updatedAt = DateTime.fromISO(getValue()!);
+        const updatedAt = DateTime.fromISO(getValue() as string);
         const timeAgo = updatedAt.toRelative({ style: "long" }) || formatter.format(0, "seconds");
         return <span title={updatedAt.toFormat("yyyy-MM-dd HH:mm:ss")}>{timeAgo}</span>;
       },
       enableSorting: true,
-    }),
+    },
   ], [selected, allSelected, approvable.length]);
 
   if (!selectedRepositories || selectedRepositories.length === 0) {


### PR DESCRIPTION
## Summary

Catches Wrangler up to the moo-ds 5.1.155 breaking change in [MooApp #562](https://github.com/AndrewMcLachlan/MooApp/pull/562):

- `accessorKey` / `accessorFn` are gone — both folded into a single `field` property.
- `createColumnHelper` is no longer exported.
- `ColumnDef<T>` is now a single-generic type re-exported from moo-ds.

Two files used the old API:

- `src/routes/pull-requests/-components/PullRequests.tsx`
- `src/routes/dashboard/-components/list/List.tsx`

Both now declare columns as plain object literals with `field`. The "select" and "actions" columns were previously `columnHelper.display()`; the new ColumnDef union has no display variant, so they pass a no-op `field: () => null` plus `enableSorting: false` and continue to render via the existing `cell` callback.

A side note: when a column array mixes string-key and function-field columns, TypeScript widens `getValue()` to the union of all `keyof T` value types. The function-field cells in `List.tsx` now read via `row.original.*` to keep types tight without `as` casts.

`package-lock.json` updated to install moo-ds@5.1.155 (manifest range was already `^5.1.155`).

## Test plan

- [x] `npm run build` clean
- [ ] Run app, navigate to Pull Requests view — table renders, sortable, select checkboxes toggle correctly, approve button still works
- [ ] Navigate to Dashboard → List view — table renders with all columns, sortable, "View Run" link works
- [ ] Verify no console errors from the DataGrid

🤖 Generated with [Claude Code](https://claude.com/claude-code)