### PR TITLE
Switch PR builds from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - "main"
-  pull_request_target:
+  pull_request:
     branches:
       - "main"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

`pull_request_target` runs the base branch's workflow with full secrets and (with the default `actions/checkout`) checks out the base branch, not the PR head. That avoids the most common foot-gun, but the side effect is that **PR CI never actually exercises the PR's source code**.

That's how the moo-ds ColumnDef breaking change introduced by Dependabot #135 went unnoticed for several days on main: every PR opened in that window saw CI "fail" against main's broken state, but no PR's actual changes were being type-checked.

Switching to `pull_request`:

- CI now builds the PR's code on every push to the branch, so type errors / build breakage are caught before they hit main.
- Secrets remain available for PRs opened from this repo (the common case); they're withheld from fork PRs by default, which is the right posture for a personal project.
- The deploy-gate conditionals (`docker-push`, `staging`, `production`, `post-production`) that exclude both event types stay unchanged. The `pull_request_target` check is now dead but harmless; happy to drop it in a follow-up.

## Notes on the security framing

The previous `pull_request_target` configuration here was *probably* not exploitable in the textbook way — the workflow doesn't set `ref:` on the checkout, so it reads the base branch's code rather than executing arbitrary PR-supplied npm scripts. But it's still a footgun magnet (any future "let's just check out the PR head" change would have leaked secrets to forks), and the visibility cost is concrete and ongoing.

## Test plan

- [ ] After merge, open a throw-away PR with a deliberate type error → confirm CI fails on the PR (not on main)
- [ ] Confirm the deploy gates still only trigger on `push` to `main`, not on PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)