### PR TITLE
Parallelise per-PR work to fix slow PR page (#147)

### DIFF
--- a/src/Wrangler.Api/Services/PullRequestService.cs
+++ b/src/Wrangler.Api/Services/PullRequestService.cs
@@ -135,18 +135,24 @@ internal class PullRequestService(IGitHubClient gitHubClient, IDistributedCache 
             await Jitter(cancellationToken);
             var prs = await OctoCall(() => gitHubClient.PullRequest.GetAllForRepository(owner, repo, new PullRequestRequest { State = ItemStateFilter.Open }), cancellationToken);
 
-            var filtered = prs.Where(pr => authors.Any(a => String.Equals(a, pr.User.Login, StringComparison.OrdinalIgnoreCase)));
+            var filtered = prs.Where(pr => authors.Any(a => String.Equals(a, pr.User.Login, StringComparison.OrdinalIgnoreCase))).ToList();
 
-            var models = new List<PullRequestModel>();
-
-            foreach (var pr in filtered)
+            // Fan out the per-PR API calls. Each task makes up to three calls
+            // (combined commit status, check runs, PR detail) in parallel. The
+            // previous loop awaited each PR before starting the next, so wall
+            // clock was O(N * round-trip); now it's bounded by the slowest
+            // single PR. OctoCall already retries on abuse / secondary rate
+            // limits, so we don't add a second throttle here.
+            var modelTasks = filtered.Select(async pr =>
             {
+                await Jitter(cancellationToken);
+
                 var checkStatusTask = GetCheckStatusAsync(owner, repo, pr.Head.Sha, cancellationToken);
                 var detailTask = OctoCall(() => gitHubClient.PullRequest.Get(owner, repo, pr.Number), cancellationToken);
 
                 await Task.WhenAll(checkStatusTask, detailTask);
 
-                models.Add(new PullRequestModel
+                return new PullRequestModel
                 {
                     Id = pr.Id,
                     Number = pr.Number,
@@ -162,10 +168,10 @@ internal class PullRequestService(IGitHubClient gitHubClient, IDistributedCache 
                     UpdatedAt = pr.UpdatedAt,
                     CheckStatus = checkStatusTask.Result,
                     Mergeable = detailTask.Result.Mergeable,
-                });
-            }
+                };
+            });
 
-            return models;
+            return await Task.WhenAll(modelTasks);
         }
         finally
         {


### PR DESCRIPTION
## Summary

`PullRequestService.GetRepoPullRequestsAsync` was doing the per-PR API work in a sequential `foreach`. Each iteration awaits three GitHub calls (combined commit status, check runs, PR detail) before starting the next PR's calls. With many filtered PRs that's exactly the O(N × round-trip-time) shape the +30 s load times in the issue describe.

Replace the loop with `Task.WhenAll` over a `Select` that builds each `PullRequestModel` independently. Per-PR cost is unchanged, but the loop itself fans out — wall clock collapses to roughly one round-trip per repo. A `Jitter()` at the start of each task spreads the initial burst so we don't fire dozens of simultaneous requests at the same millisecond.

`OctoCall` already retries on `AbuseException` / `RateLimitExceededException` with backoff, so no extra throttle is added in this PR. If real-world load trips GitHub's secondary rate limit we can introduce a bounded inner gate later.

## What this doesn't address (worth a follow-up)

- We still make a separate `gitHubClient.PullRequest.Get(...)` call per PR purely to read `Mergeable`. GraphQL could fetch the merge state for all PRs in a repo in one request. Bigger change; left for a separate PR.
- The `_gate = new(8)` still bounds *repo-level* concurrency. With this change, all per-PR work inside one repo's slot runs in parallel, which is the intended behaviour for fast loading.

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 70 tests pass
- [ ] Open the PR page against the same large-repo configuration referenced in #147 and confirm load time drops back into single-digit seconds
- [ ] Watch the API logs for any AbuseException / RateLimitExceededException retries — small bursts are fine, sustained retries suggest we need to bound inner concurrency

🤖 Generated with [Claude Code](https://claude.com/claude-code)