### PR TITLE
Link branch names to GitHub Actions; fix attention icon hit area

### DIFF
--- a/src/Wrangler.App/src/css/components.css
+++ b/src/Wrangler.App/src/css/components.css
@@ -1,4 +1,5 @@
 @import "./components/badge.css";
+@import "./components/branch-link.css";
 @import "./components/collapsible.css";
 @import "./components/controls.css";
 @import "./components/filters.css";

--- a/src/Wrangler.App/src/css/components/branch-link.css
+++ b/src/Wrangler.App/src/css/components/branch-link.css
@@ -1,0 +1,12 @@
+/* Wraps a branch Badge in a link to the GitHub PR list filtered to the branch.
+   Resets default anchor styling so the badge looks unchanged. */
+.branch-link {
+  display: inline-flex;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.branch-link:hover .badge {
+  filter: brightness(1.15);
+}

--- a/src/Wrangler.App/src/css/components/overview/overview.css
+++ b/src/Wrangler.App/src/css/components/overview/overview.css
@@ -133,10 +133,6 @@
     border-radius: 4px;
     transition: background-color 0.1s;
 
-    &:hover {
-      background-color: rgba(255, 255, 255, 0.04);
-    }
-
     .workflow-run-info > .status-indicator {
       width: 0.8rem;
       height: 0.8rem;
@@ -186,6 +182,12 @@
     font-size: 0.75rem;
     opacity: 0.5;
     white-space: nowrap;
+    color: inherit;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 
   .passing-summary {

--- a/src/Wrangler.App/src/css/layout.css
+++ b/src/Wrangler.App/src/css/layout.css
@@ -69,6 +69,13 @@
             border-radius: 50%;
             background: #ff4444;
         }
+
+        /* The Stack icon ships with a 112mm intrinsic size; constrain it so it
+           matches the other (32px) nav icons and its hit area stays in the button. */
+        .attention-link svg {
+            width: 2rem;
+            height: 2rem;
+        }
     }
 }
 

--- a/src/Wrangler.App/src/routes/dashboard/-components/list/List.tsx
+++ b/src/Wrangler.App/src/routes/dashboard/-components/list/List.tsx
@@ -3,6 +3,7 @@ import { DateTime } from "luxon";
 import type { RepositoryModel, WorkflowModel, WorkflowRunModel } from "../../../../api";
 import { useWorkflows } from "../../-hooks/useWorkflows";
 import { Badge } from "../shared/Badge";
+import { BranchBadge } from "../shared/BranchBadge";
 
 interface WorkflowRunItem {
   repo: RepositoryModel;
@@ -30,7 +31,7 @@ const columns: ColumnDef<WorkflowRunItem>[] = [
     field: (item: WorkflowRunItem) => item.run.headBranch,
     id: "branch",
     header: "Branch",
-    cell: ({ row }) => <Badge>{row.original.run.headBranch}</Badge>,
+    cell: ({ row }) => <BranchBadge run={row.original.run} />,
     enableSorting: true,
   },
   {

--- a/src/Wrangler.App/src/routes/dashboard/-components/nested/WorkflowRunCard.tsx
+++ b/src/Wrangler.App/src/routes/dashboard/-components/nested/WorkflowRunCard.tsx
@@ -1,6 +1,6 @@
 import { Icon } from "@andrewmclachlan/moo-ds";
 import type { WorkflowRunModel } from "../../../../api";
-import { Badge } from "../shared/Badge";
+import { BranchBadge } from "../shared/BranchBadge";
 import StatusIndicator from "../shared/StatusIndicator";
 import { DateTime } from "luxon";
 
@@ -15,7 +15,7 @@ export const WorkflowRunCard: React.FC<WorkflowRunCardProps> = ({ workflowRun })
     <section className="workflow-run-card">
       <StatusIndicator status={workflowRun.workflowStatus} />
       <span className="conclusion">{workflowRun.conclusion}</span>
-      <Badge className="branch">{workflowRun.headBranch}</Badge>
+      <BranchBadge run={workflowRun} className="branch" />
       <span>{workflowRun.event}</span>
       <span>{workflowRun.runNumber}</span>
       <span>{workflowRun.triggeringActor}</span>

--- a/src/Wrangler.App/src/routes/dashboard/-components/overview/RunInfo.tsx
+++ b/src/Wrangler.App/src/routes/dashboard/-components/overview/RunInfo.tsx
@@ -1,7 +1,7 @@
 import { DateTime } from "luxon";
 import type { WorkflowRunModel } from "../../../../api";
 import StatusIndicator from "../shared/StatusIndicator";
-import { Badge } from "../shared/Badge";
+import { BranchBadge } from "../shared/BranchBadge";
 import classNames from "classnames";
 
 export const RunInfo: React.FC<{ run: WorkflowRunModel; orientation?: "left" | "right" }> = ({ run, orientation = "left" }) => {
@@ -9,13 +9,19 @@ export const RunInfo: React.FC<{ run: WorkflowRunModel; orientation?: "left" | "
   const timeAgo = DateTime.fromISO(run.updatedAt).toRelative({ style: "long" }) || formatter.format(0, "seconds");
 
   return (
-    <a className={classNames("workflow-run-info", orientation)} href={run.htmlUrl} target="_blank" rel="noopener noreferrer">
+    <div className={classNames("workflow-run-info", orientation)}>
       {orientation === "left" && <StatusIndicator status={run.workflowStatus} />}
-      <Badge className="branch">{run.headBranch}</Badge>
-      <span className="workflow-time" title={DateTime.fromISO(run.updatedAt).toFormat("yyyy-MM-dd HH:mm:ss")}>
+      <BranchBadge run={run} className="branch" />
+      <a
+        className="workflow-time"
+        href={run.htmlUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={DateTime.fromISO(run.updatedAt).toFormat("yyyy-MM-dd HH:mm:ss")}
+      >
         {timeAgo}
-      </span>
+      </a>
       {orientation === "right" && <StatusIndicator status={run.workflowStatus} />}
-    </a>
+    </div>
   );
 };

--- a/src/Wrangler.App/src/routes/dashboard/-components/shared/BranchBadge.tsx
+++ b/src/Wrangler.App/src/routes/dashboard/-components/shared/BranchBadge.tsx
@@ -1,0 +1,36 @@
+import type { MouseEventHandler } from "react";
+import type { WorkflowRunModel } from "../../../../api";
+import { Badge } from "./Badge";
+
+// run.htmlUrl looks like https://github.com/{owner}/{repo}/actions/runs/{id}.
+// The repo base is everything before /actions/, which we turn into the Actions
+// list filtered to the run's head branch.
+const actionsUrl = (run: WorkflowRunModel): string | undefined => {
+  const repoBase = run.htmlUrl?.split("/actions/")[0];
+  if (!repoBase || !run.headBranch) return undefined;
+  const query = encodeURIComponent(`branch:${run.headBranch}`);
+  return `${repoBase}/actions?query=${query}`;
+};
+
+export const BranchBadge: React.FC<{ run: WorkflowRunModel; className?: string }> = ({ run, className }) => {
+  const url = actionsUrl(run);
+  const badge = <Badge className={className}>{run.headBranch}</Badge>;
+
+  if (!url) return badge;
+
+  // stopPropagation keeps the badge from triggering an enclosing run link.
+  const onClick: MouseEventHandler = (e) => e.stopPropagation();
+
+  return (
+    <a
+      className="branch-link"
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={`View workflow runs for ${run.headBranch}`}
+      onClick={onClick}
+    >
+      {badge}
+    </a>
+  );
+};


### PR DESCRIPTION
## Summary
- Branch badges on the dashboard (list view, nested run cards, and the overview) now link to the repository's **GitHub Actions list filtered to that branch** (`/actions?query=branch:<branch>`), via a new shared `BranchBadge` component.
- `RunInfo` was restructured: previously the whole row was a single `<a>` to the run, so nesting the branch link inside it would be invalid HTML. The row is now a `<div>` and the **timestamp** carries the run link instead.
- Fixed the **attention nav link** (top-right): its `Stack` icon ships with a `112mm` (~423px) intrinsic size and overflowed the 30px button, leaving a large invisible click target running down the page. Constrained it to `2rem` to match the other nav icons.

## Notes
- One behavioural change in the overview: clicking the row used to open the run anywhere; now the branch opens the Actions list and the timestamp opens the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
