### PR TITLE
Hide repos with no selected workflows from the dashboard (#172)

### DIFF
--- a/src/Wrangler.Api/Services/DashboardService.cs
+++ b/src/Wrangler.Api/Services/DashboardService.cs
@@ -119,7 +119,10 @@ internal class DashboardService(IGitHubClient gitHubClient, IDistributedCache ca
             workflowRuns.AddRange(runTask.Result);
         }
 
-        foreach (var workflowRepo in workflows)
+        // Skip repos whose selected workflows resolved to nothing (e.g. all
+        // workflows deselected in settings) so the dashboard doesn't render an
+        // empty card for them (issue #172).
+        foreach (var workflowRepo in workflows.Where(wr => wr.Value.Any()))
         {
             results.Add(new RepositoryModel
             {

--- a/src/Wrangler.App/src/routes/dashboard/-hooks/useWorkflows.ts
+++ b/src/Wrangler.App/src/routes/dashboard/-hooks/useWorkflows.ts
@@ -94,7 +94,10 @@ export const useWorkflows = () => {
     queryFn: async () => {
       var result = await postWorkflows({
         body: {
-          repositories: selectedRepositories,
+          // A repo with no selected workflows has nothing to show on the
+          // dashboard, so exclude it here rather than fetch and render an
+          // empty card (issue #172). The entry stays in settings/PR scope.
+          repositories: selectedRepositories.filter((r) => (r.workflows?.length ?? 0) > 0),
           branchFilters: branchFilter?.length ? branchFilter : undefined,
         }
       })


### PR DESCRIPTION
## Summary

Fixes #172 — turning off all workflows for a repo left it showing on the dashboard.

## Root cause

When the last workflow for a repo is deselected in settings, the repo entry stays in `localStorage` with `workflows: []` (intentional — the entry is still needed for PR scope and to re-enable later). But nothing excluded a zero-workflow repo from the dashboard:

- `useWorkflows` sent the entire selected list, including empty-workflow repos.
- `DashboardService.GetWorkflowsAsync` built a `RepositoryModel` for **every** requested repo, even when its matched workflow set was empty.
- The overview/card view (`AccountSection`, `RepositoryList`) renders a card per returned repo with no `workflows.length > 0` guard — so an empty card appeared. (The list/table view already hid it, since it flat-maps down to runs.)

## Fix

Exclude zero-workflow repos at the dashboard data boundary — **not** by deleting the repo from storage (that would also remove it from settings and PR scope):

- **Frontend** (`useWorkflows.ts`): filter the request to repos with `(workflows?.length ?? 0) > 0`. Bonus: the backend no longer fetches a repo you've fully disabled on every refresh.
- **Backend** (`DashboardService.cs`): `.Where(wr => wr.Value.Any())` guard so the workflows endpoint never returns an empty-workflow repo.

This matches the existing convention in `RepoSelector.tsx`, which already treats `(repo.workflows?.length ?? 0) === 0` as non-actionable.

## Verification

- Frontend `npm run build` and backend `dotnet build` both pass.
- Confirmed against the settings add/toggle/clear flow that empty `workflows` means "none selected" (never "show all"), so the filter cannot hide a newly-added repo.

_Not driven in the live app (needs an authenticated GitHub session); the logic is verified against the actual storage/render flow._

🤖 Generated with [Claude Code](https://claude.com/claude-code)