### PR TITLE
Rethink PR view repository and author filters (#143)

### DIFF
--- a/docs/superpowers/specs/2026-07-18-pr-filters-rethink-design.md
+++ b/docs/superpowers/specs/2026-07-18-pr-filters-rethink-design.md
@@ -1,0 +1,112 @@
+# PR View Filters Rethink (#143) — Design
+
+Date: 2026-07-18
+Status: Approved
+
+## Summary
+
+The Pull Requests view reuses the workflow dashboard's "selected repositories"
+list and a free-text author input. Issue #143 asks for two independent changes:
+
+- **Part A** — give the PR view its own repository scope, independent of the
+  workflow dashboard.
+- **Part B** — replace the free-text author filter with a debounced GitHub-user
+  typeahead.
+
+Delivered as one PR closing #143, with Part A and Part B as separate commits.
+
+## Part A — Independent PR repository scope
+
+### Hook
+
+`src/Wrangler.App/src/routes/pull-requests/-hooks/usePrRepositories.ts`
+(+ `useUpdatePrRepositories`), mirroring `usePrAuthors.ts` (react-query +
+localStorage, so the value feeds the PR fetch query key and edits refetch).
+
+- localStorage key: `"prRepositories"`, storing `{ owner: string, name: string }[]`.
+- **Seeding (read-time default):** if the `"prRepositories"` key is absent, fall
+  back to the current `"repositories"` (dashboard) selection mapped to
+  `{ owner, name }`. Once the mutation writes the key, the scope is independent;
+  an intentionally-emptied scope persists as `[]` because the key now exists.
+  This distinguishes "never configured → seed" from "emptied on purpose".
+
+### Consumption
+
+- `usePullRequests.ts`: use `usePrRepositories()` instead of
+  `useSelectedRepositories()`. Shapes already match (`{ owner, name }`), and
+  `repositories` is already in the query key + the `enabled` guard.
+- `PullRequests.tsx`: drop the settings-oriented `NoRepositories` guard. Repos
+  are now chosen inline, so an empty scope shows the picker plus an empty grid
+  ("Select repositories to see pull requests."). The fetch stays gated (no fetch
+  until repositories **and** authors are non-empty).
+
+### Picker UI
+
+A moo-ds `ComboBox multiSelect` at the top of the PR controls, fed by
+`useRepositories()` (the full accessible list from `GET /repositories`).
+Suggestions are entirely client-side (list already loaded), so ComboBox fits.
+
+- Bridge shape: `Repository.owner` is a `User` object → map items to
+  `{ owner: r.owner.login, name: r.name, id: r.id, label: r.fullName ?? owner/name }`.
+- `labelField` = full name, `valueField` = `owner/name`, `selectedItems` from
+  `prRepositories`, `onChange` → `setPrRepositories(items.map({owner,name}))`.
+
+## Part B — Debounced GitHub-user author typeahead
+
+### Backend
+
+New endpoint `GET /users/search?q={query}`:
+
+- Handler `UsersHandler.Handle` (static, per convention), mapped in `Program.cs`.
+- Service method wrapping Octokit `Search.SearchUsers(new SearchUsersRequest(q))`,
+  mapped to a lean model `UserSearchResult { Login, Name?, AvatarUrl? }`, top ~10.
+- Short-TTL distributed cache per normalised query (reuse `GitHubService`
+  cache helpers). On rate-limit/403, return an empty list gracefully rather than
+  erroring the typeahead.
+- Requires client regen: `dotnet build` (emits `openapi-v1.json`) →
+  `npm run generate`.
+
+### Frontend
+
+- `useUserSearch(query)` — react-query keyed on the **debounced** query
+  (`use-debounce`, already a dependency), enabled only when the debounced query
+  length ≥ 2. Calls the generated `getUsersSearch`.
+- **Control:** enhance the existing author input + `CloseBadge` chips rather than
+  use `ComboBox` — moo-ds `ComboBox`'s `search` is client-side only
+  (`(input) => TItem[]`, no async/input-change hook), which cannot drive a server
+  query. So: keep the controlled input, add a debounced suggestions dropdown
+  (avatar + login) beneath it; clicking a suggestion adds a chip. **Typing an
+  exact login + Enter still adds it** (creatable), preserving the ability to add
+  bots like `dependabot[bot]`/`renovate[bot]` (the current defaults) that user
+  search won't surface. Existing free-text add semantics are retained.
+
+## Data Flow
+
+1. `useRepositories` → repo picker options (Part A).
+2. `usePrRepositories` (seeded from dashboard selection) → PR fetch scope.
+3. Author input text → debounced → `useUserSearch` → suggestions dropdown.
+4. Selected authors (strings) + repositories feed `["pullRequests", repos, authors]`.
+5. Backend filters PRs by author server-side (unchanged).
+
+## Edge Cases
+
+- **Seeded vs emptied scope:** key-absent seeds from dashboard; key-present-empty
+  stays empty.
+- **Bots / exact logins:** always addable via free-text Enter, independent of
+  search results.
+- **Search rate limit (~30/min):** mitigated by ≥2-char minimum, debounce, and
+  per-query caching; 403 returns empty suggestions, not an error.
+- **Repo owner shape mismatch:** `Repository.owner.login` bridged to flat
+  `{ owner, name }` for storage and the PR request.
+
+## Out of Scope
+
+- Changing server-side author filtering semantics.
+- Collaborator/org-member based suggestions (chose GitHub user search).
+- #146's "awaiting my review" cut (separate issue).
+
+## Testing
+
+- Frontend `npm run build`, backend `dotnet build`.
+- Manual: repo scope independence + seeding, author typeahead suggestions,
+  exact-login/bot entry, persistence across reload.

--- a/src/Wrangler.Api/Handlers/UserSearchHandler.cs
+++ b/src/Wrangler.Api/Handlers/UserSearchHandler.cs
@@ -1,0 +1,24 @@
+using Asm.Wrangler.Api.Models.Users;
+using Asm.Wrangler.Api.Services;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Asm.Wrangler.Api.Handlers;
+
+/// <summary>
+/// Handles GitHub user search for the pull-request author typeahead.
+/// </summary>
+public static class UserSearchHandler
+{
+    /// <summary>
+    /// Searches GitHub users matching the query string <paramref name="q"/>.
+    /// </summary>
+    public static async Task<Ok<IEnumerable<UserSearchResult>>> Handle(
+        [FromServices] IUserSearchService service,
+        [FromQuery] string q,
+        CancellationToken cancellationToken)
+    {
+        var results = await service.SearchUsersAsync(q ?? string.Empty, cancellationToken);
+        return TypedResults.Ok(results);
+    }
+}

--- a/src/Wrangler.Api/Models/Users/UserSearchResult.cs
+++ b/src/Wrangler.Api/Models/Users/UserSearchResult.cs
@@ -1,0 +1,16 @@
+namespace Asm.Wrangler.Api.Models.Users;
+
+/// <summary>
+/// A GitHub user returned from the pull-request author-search typeahead.
+/// </summary>
+public record UserSearchResult
+{
+    /// <summary>The user's GitHub login.</summary>
+    public required string Login { get; init; }
+
+    /// <summary>The user's display name, if GitHub has one for them.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>URL of the user's avatar image.</summary>
+    public string? AvatarUrl { get; init; }
+}

--- a/src/Wrangler.Api/Program.cs
+++ b/src/Wrangler.Api/Program.cs
@@ -73,6 +73,7 @@ static void AddServices(WebApplicationBuilder builder)
     builder.Services.AddScoped<IPullRequestService, PullRequestService>();
     builder.Services.AddScoped<IAttentionService, AttentionService>();
     builder.Services.AddScoped<IGateService, GateService>();
+    builder.Services.AddScoped<IUserSearchService, UserSearchService>();
     builder.Services.AddSingleton<ICacheKeyService, CacheKeyService>();
     builder.Services.AddSingleton<IResponseCache, DistributedResponseCache>();
     builder.Services.AddSingleton<IInstallationRegistry, InstallationRegistry>();
@@ -258,6 +259,7 @@ static void AddApp(WebApplication app)
     api.MapGet("me", MeHandler.Handle);
     api.MapGet("repositories", RepositoriesHandler.Handle);
     api.MapGet("repositories/grouped", GroupedRepositoriesHandler.Handle);
+    api.MapGet("users/search", UserSearchHandler.Handle);
     api.MapPost("workflows", WorkflowsHandler.Handle).DisableAntiforgery();
 
     api.MapPost("repositories/{owner}/{repo}/workflows/", RepositoriesWorkflowsHandler.Handle)

--- a/src/Wrangler.Api/Services/UserSearchService.cs
+++ b/src/Wrangler.Api/Services/UserSearchService.cs
@@ -1,0 +1,74 @@
+using Asm.Wrangler.Api.Models.Users;
+using Microsoft.Extensions.Caching.Distributed;
+using Octokit;
+
+namespace Asm.Wrangler.Api.Services;
+
+/// <summary>
+/// Searches GitHub users for the pull-request author typeahead.
+/// </summary>
+public interface IUserSearchService
+{
+    /// <summary>
+    /// Searches GitHub users matching the given query. Returns an empty list for
+    /// queries shorter than two characters or when the search cannot be served.
+    /// </summary>
+    /// <param name="query">The partial login/name to search for.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    Task<IEnumerable<UserSearchResult>> SearchUsersAsync(string query, CancellationToken cancellationToken);
+}
+
+internal class UserSearchService(IGitHubClient gitHubClient, IDistributedCache cache, ICacheKeyService cacheKeyService, ILogger<UserSearchService> logger)
+    : GitHubService(cache, logger), IUserSearchService
+{
+    private const int MaxResults = 10;
+    private const int MinQueryLength = 2;
+
+    public async Task<IEnumerable<UserSearchResult>> SearchUsersAsync(string query, CancellationToken cancellationToken)
+    {
+        query = query.Trim();
+        if (query.Length < MinQueryLength)
+        {
+            return [];
+        }
+
+        var cacheKey = cacheKeyService.GetCacheKey($"gh:users:search:{query.ToLowerInvariant()}");
+
+        var cached = await TryGetFromCache<UserSearchResult>(cacheKey, cancellationToken);
+        if (cached != null)
+        {
+            return cached;
+        }
+
+        try
+        {
+            await Jitter(cancellationToken);
+            var response = await OctoCall(() => gitHubClient.Search.SearchUsers(new SearchUsersRequest(query)
+            {
+                PerPage = MaxResults,
+                Page = 1,
+            }), cancellationToken);
+
+            var results = response.Items
+                .Take(MaxResults)
+                .Select(u => new UserSearchResult
+                {
+                    Login = u.Login,
+                    Name = u.Name,
+                    AvatarUrl = u.AvatarUrl,
+                })
+                .ToList();
+
+            await TryCache(cacheKey, results, cancellationToken);
+
+            return results;
+        }
+        catch (RateLimitExceededException)
+        {
+            // The author typeahead should degrade quietly rather than surface an
+            // error; the Search API's low limit makes this a realistic outcome.
+            logger.LogWarning("GitHub user search rate limit reached; returning no suggestions.");
+            return [];
+        }
+    }
+}

--- a/src/Wrangler.Api/openapi-v1.json
+++ b/src/Wrangler.Api/openapi-v1.json
@@ -68,6 +68,38 @@
         }
       }
     },
+    "/users/search": {
+      "get": {
+        "tags": [
+          "UserSearchHandler"
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserSearchResult"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/workflows": {
       "post": {
         "tags": [
@@ -1683,6 +1715,29 @@
           }
         }
       },
+      "UserSearchResult": {
+        "required": [
+          "login"
+        ],
+        "type": "object",
+        "properties": {
+          "login": {
+            "type": "string"
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "avatarUrl": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
       "WorkflowBase": {
         "required": [
           "nodeId",
@@ -1882,6 +1937,9 @@
     },
     {
       "name": "GroupedRepositoriesHandler"
+    },
+    {
+      "name": "UserSearchHandler"
     },
     {
       "name": "WorkflowsHandler"

--- a/src/Wrangler.App/src/css/components/pull-requests.css
+++ b/src/Wrangler.App/src/css/components/pull-requests.css
@@ -30,6 +30,30 @@
         min-width: 0;
     }
 
+    /* The PR view's own repository scope (issue #143) sits on its own row at
+       the top of the controls, above the author/status/tag filters. */
+    .pr-repositories {
+        flex-basis: 100%;
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+    }
+
+    .pr-repositories-label {
+        font-size: 0.78rem;
+        color: rgba(255, 255, 255, 0.55);
+        white-space: nowrap;
+    }
+
+    .repository-scope {
+        --input-padding-v: 0.375rem;
+        --input-padding-h: 0.75rem;
+        flex: 1 1 auto;
+        min-width: 240px;
+        max-width: 520px;
+        font-size: 0.85rem;
+    }
+
     .author-input {
         max-width: 300px;
         background: rgba(255, 255, 255, 0.04);

--- a/src/Wrangler.App/src/css/components/pull-requests.css
+++ b/src/Wrangler.App/src/css/components/pull-requests.css
@@ -54,8 +54,16 @@
         font-size: 0.85rem;
     }
 
-    .author-input {
+    /* Author typeahead (issue #143): the input plus an absolutely-positioned
+       suggestions dropdown from the debounced GitHub user search. */
+    .author-filter {
+        position: relative;
+        flex: 1 1 200px;
         max-width: 300px;
+    }
+
+    .author-input {
+        width: 100%;
         background: rgba(255, 255, 255, 0.04);
         border-color: rgba(255, 255, 255, 0.1);
 
@@ -63,6 +71,55 @@
             border-color: var(--primary);
             box-shadow: 0 0 0 2px rgba(212, 162, 78, 0.15);
         }
+    }
+
+    .author-suggestions {
+        position: absolute;
+        top: calc(100% + 4px);
+        left: 0;
+        right: 0;
+        z-index: 20;
+        margin: 0;
+        padding: 0.25rem 0;
+        list-style: none;
+        max-height: 240px;
+        overflow-y: auto;
+        background: var(--body-bg, #1a1a1a);
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        border-radius: 0.375rem;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+
+        li {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            padding: 0.35rem 0.6rem;
+            cursor: pointer;
+            font-size: 0.85rem;
+
+            &:hover {
+                background: rgba(255, 255, 255, 0.06);
+            }
+        }
+    }
+
+    .author-suggestion-avatar {
+        width: 18px;
+        height: 18px;
+        border-radius: 50%;
+        flex-shrink: 0;
+    }
+
+    .author-suggestion-login {
+        color: #fff;
+    }
+
+    .author-suggestion-name {
+        color: rgba(255, 255, 255, 0.5);
+        font-size: 0.78rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 
     .author-badges {

--- a/src/Wrangler.App/src/routes/pull-requests/-components/PullRequests.tsx
+++ b/src/Wrangler.App/src/routes/pull-requests/-components/PullRequests.tsx
@@ -10,6 +10,7 @@ import { usePrAuthors, useUpdatePrAuthors } from "../-hooks/usePrAuthors";
 import { usePrStatusFilter } from "../-hooks/usePrStatusFilter";
 import { usePrIncludeTags, usePrExcludeTags } from "../-hooks/usePrTagFilter";
 import { usePrRepositories, useUpdatePrRepositories } from "../-hooks/usePrRepositories";
+import { useUserSearch } from "../-hooks/useUserSearch";
 import { useApprovePullRequests } from "../-hooks/useApprovePullRequests";
 import { useRepositories } from "../../../hooks/useRepositories";
 import { Badge } from "@andrewmclachlan/moo-ds";
@@ -64,6 +65,9 @@ export const PullRequests = () => {
   const [excludeTags, setExcludeTags] = usePrExcludeTags();
   const [alerts, setAlerts] = useState<ApprovalResult[]>([]);
   const [selected, setSelected] = useState<Set<number | string>>(new Set());
+  const [authorQuery, setAuthorQuery] = useState("");
+  const [authorFocused, setAuthorFocused] = useState(false);
+  const { data: authorSuggestions } = useUserSearch(authorQuery);
 
   const { mutate: approvePullRequests, isPending: isApproving } = useApprovePullRequests({
     onResults: (results) => {
@@ -213,24 +217,31 @@ export const PullRequests = () => {
     // selected so the user can act on them again.
   };
 
-  const checkInput = (e: React.FocusEvent<HTMLInputElement> | React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.type === "keyup") {
-      const keyEvent = e as React.KeyboardEvent<HTMLInputElement>;
-      if (keyEvent.key !== "Enter" && keyEvent.key !== " " && keyEvent.key !== "," && keyEvent.key !== ";") {
-        return;
-      }
+  // Add an author by exact login — used both for typeahead selections and for
+  // typing a login directly (so bots like dependabot[bot], which user search
+  // won't surface, stay addable).
+  const addAuthor = (value: string) => {
+    const login = value.trim().replace(/[,;]/g, "");
+    if (login !== "" && !authors.includes(login)) {
+      updateAuthors([...authors, login]);
+    }
+    setAuthorQuery("");
+  };
+
+  const checkInput = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter" && e.key !== " " && e.key !== "," && e.key !== ";") {
+      return;
     }
     e.preventDefault();
-    const value = e.currentTarget.value.trim();
-    if (value !== "" && !authors.includes(value)) {
-      updateAuthors([...authors, value]);
-      e.currentTarget.value = "";
-    }
+    addAuthor(authorQuery);
   };
 
   const removeAuthor = (author: string) => {
     updateAuthors(authors.filter(a => a !== author));
   };
+
+  const showAuthorSuggestions =
+    authorFocused && authorQuery.trim().length >= 2 && (authorSuggestions?.length ?? 0) > 0;
 
   const columns: ColumnDef<PullRequestModel>[] = useMemo(() => [
     {
@@ -336,7 +347,33 @@ export const PullRequests = () => {
           />
         </div>
         <div className="pr-filters">
-          <input type="text" className="form-control author-input" placeholder="Add author filter..." onKeyUp={checkInput} onBlur={checkInput} />
+          <div className="author-filter">
+            <input
+              type="text"
+              className="form-control author-input"
+              placeholder="Filter by author..."
+              value={authorQuery}
+              onChange={(e) => setAuthorQuery(e.target.value)}
+              onKeyUp={checkInput}
+              onFocus={() => setAuthorFocused(true)}
+              onBlur={() => setAuthorFocused(false)}
+              role="combobox"
+              aria-expanded={showAuthorSuggestions}
+              aria-autocomplete="list"
+            />
+            {showAuthorSuggestions && (
+              <ul className="author-suggestions" role="listbox">
+                {authorSuggestions!.map((user) => (
+                  // onMouseDown fires before the input's blur, so the click registers.
+                  <li key={user.login} role="option" aria-selected={false} onMouseDown={() => addAuthor(user.login)}>
+                    {user.avatarUrl && <img className="author-suggestion-avatar" src={user.avatarUrl} alt="" />}
+                    <span className="author-suggestion-login">{user.login}</span>
+                    {user.name && <span className="author-suggestion-name">{user.name}</span>}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
           <div className="status-filter" role="group" aria-label="Filter by check status">
             {STATUS_OPTIONS.map((status) => (
               <button

--- a/src/Wrangler.App/src/routes/pull-requests/-components/PullRequests.tsx
+++ b/src/Wrangler.App/src/routes/pull-requests/-components/PullRequests.tsx
@@ -9,11 +9,11 @@ import { usePullRequests } from "../-hooks/usePullRequests";
 import { usePrAuthors, useUpdatePrAuthors } from "../-hooks/usePrAuthors";
 import { usePrStatusFilter } from "../-hooks/usePrStatusFilter";
 import { usePrIncludeTags, usePrExcludeTags } from "../-hooks/usePrTagFilter";
+import { usePrRepositories, useUpdatePrRepositories } from "../-hooks/usePrRepositories";
 import { useApprovePullRequests } from "../-hooks/useApprovePullRequests";
-import { useSelectedRepositories } from "../../settings/-hooks/useSelectedRepositories";
+import { useRepositories } from "../../../hooks/useRepositories";
 import { Badge } from "@andrewmclachlan/moo-ds";
 import { CheckStatusBadge } from "./CheckStatusBadge";
-import { NoRepositories } from "../../../components/NoRepositories";
 import type { ApprovalResult, CheckStatus, PullRequestModel } from "../../../api";
 
 export const canApprove = (pr: PullRequestModel) => pr.checkStatus === "Success" && pr.mergeable !== false;
@@ -41,10 +41,21 @@ interface TagOption {
 // present on any currently-loaded PR, so its chip still renders.
 const FALLBACK_TAG_COLOUR = "6e7681";
 
+interface RepoOption {
+  owner: string;
+  name: string;
+  id: string;
+  label: string;
+}
+
+const repoKey = (owner: string, name: string) => `${owner}/${name}`;
+
 export const PullRequests = () => {
 
   const queryClient = useQueryClient();
-  const { data: selectedRepositories } = useSelectedRepositories();
+  const { data: prRepositories } = usePrRepositories();
+  const { mutate: updatePrRepositories } = useUpdatePrRepositories();
+  const { data: availableRepositories } = useRepositories();
   const { data: authors } = usePrAuthors();
   const { mutate: updateAuthors } = useUpdatePrAuthors();
   const { data: pullRequests, isLoading, isError, error } = usePullRequests();
@@ -99,6 +110,32 @@ export const PullRequests = () => {
     else next.add(status);
     setStatusFilter([...next]);
   };
+
+  // Every repository the user can access, as options for the PR scope picker.
+  const repoOptions = useMemo<RepoOption[]>(() =>
+    (availableRepositories ?? [])
+      .filter((r) => r.owner?.login && r.name)
+      .map((r) => ({
+        owner: r.owner!.login!,
+        name: r.name!,
+        id: repoKey(r.owner!.login!, r.name!),
+        label: r.fullName ?? repoKey(r.owner!.login!, r.name!),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+    [availableRepositories]);
+
+  // The currently-scoped repos as picker options; a scoped repo missing from the
+  // accessible list still renders as a removable chip (owner/name fallback).
+  const selectedRepoOptions = useMemo<RepoOption[]>(() => {
+    const byKey = new Map(repoOptions.map((o) => [repoKey(o.owner, o.name), o]));
+    return prRepositories.map((r) =>
+      byKey.get(repoKey(r.owner, r.name)) ?? {
+        owner: r.owner,
+        name: r.name,
+        id: repoKey(r.owner, r.name),
+        label: repoKey(r.owner, r.name),
+      });
+  }, [prRepositories, repoOptions]);
 
   // Deduplicated union of labels across the loaded PRs (first-seen colour wins),
   // sorted by name — this is the typeahead suggestion set for both tag filters.
@@ -280,15 +317,24 @@ export const PullRequests = () => {
     },
   ], [selected, allSelected, approvable.length, isApproving]);
 
-  if (!selectedRepositories || selectedRepositories.length === 0) {
-    return <NoRepositories />;
-  }
-
   return (
     <article className="pull-requests">
       <h2>Pull Requests</h2>
 
       <div className="controls">
+        <div className="pr-repositories">
+          <span className="pr-repositories-label">Repositories</span>
+          <ComboBox<RepoOption>
+            className="repository-scope"
+            placeholder="Add repositories..."
+            multiSelect
+            items={repoOptions}
+            selectedItems={selectedRepoOptions}
+            labelField={(r) => r.label}
+            valueField={(r) => r.id}
+            onChange={(items) => updatePrRepositories(items.map((r) => ({ owner: r.owner, name: r.name })))}
+          />
+        </div>
         <div className="pr-filters">
           <input type="text" className="form-control author-input" placeholder="Add author filter..." onKeyUp={checkInput} onBlur={checkInput} />
           <div className="status-filter" role="group" aria-label="Filter by check status">
@@ -367,7 +413,7 @@ export const PullRequests = () => {
         columns={columns}
         sortable
         loading={isLoading}
-        emptyMessage="No open pull requests found."
+        emptyMessage={prRepositories.length === 0 ? "Select repositories to see pull requests." : "No open pull requests found."}
       />
     </article>
   );

--- a/src/Wrangler.App/src/routes/pull-requests/-hooks/usePrRepositories.ts
+++ b/src/Wrangler.App/src/routes/pull-requests/-hooks/usePrRepositories.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+export interface PrRepository {
+  owner: string;
+  name: string;
+}
+
+/**
+ * The repositories scoped to the Pull Requests view, independent of the
+ * workflow dashboard's selected repositories (issue #143).
+ *
+ * On first use (the "prRepositories" key is absent) the scope is seeded from
+ * the dashboard's "repositories" selection so existing users see PRs straight
+ * away. Once edited, the mutation writes the key and the scope is fully
+ * independent — an intentionally-emptied scope persists as [] because the key
+ * then exists.
+ */
+const readPrRepositories = (): PrRepository[] => {
+  const stored = localStorage.getItem("prRepositories");
+  if (stored !== null) {
+    return JSON.parse(stored) as PrRepository[];
+  }
+
+  const selected = localStorage.getItem("repositories");
+  if (!selected) return [];
+  try {
+    const parsed = JSON.parse(selected) as PrRepository[];
+    return parsed.map(r => ({ owner: r.owner, name: r.name }));
+  } catch {
+    return [];
+  }
+};
+
+export const usePrRepositories = () => {
+  const data = readPrRepositories();
+  return useQuery({
+    queryKey: ["prRepositories", data],
+    queryFn: () => data,
+    initialData: [],
+  });
+};
+
+export const useUpdatePrRepositories = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (repositories: PrRepository[]) => {
+      localStorage.setItem("prRepositories", JSON.stringify(repositories));
+    },
+    onSettled: () => {
+      queryClient.refetchQueries({ queryKey: ["prRepositories"] });
+    },
+  });
+};

--- a/src/Wrangler.App/src/routes/pull-requests/-hooks/usePrRepositories.ts
+++ b/src/Wrangler.App/src/routes/pull-requests/-hooks/usePrRepositories.ts
@@ -36,7 +36,7 @@ export const usePrRepositories = () => {
   return useQuery({
     queryKey: ["prRepositories", data],
     queryFn: () => data,
-    initialData: [],
+    initialData: data,
   });
 };
 

--- a/src/Wrangler.App/src/routes/pull-requests/-hooks/usePullRequests.ts
+++ b/src/Wrangler.App/src/routes/pull-requests/-hooks/usePullRequests.ts
@@ -1,14 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
-import { useSelectedRepositories } from "../../settings/-hooks/useSelectedRepositories";
+import { usePrRepositories } from "./usePrRepositories";
 import { usePrAuthors } from "./usePrAuthors";
 import { postPullRequests } from "../../../api";
 
 export const usePullRequests = () => {
 
-  const { data: selectedRepositories } = useSelectedRepositories();
+  const { data: prRepositories } = usePrRepositories();
   const { data: authors } = usePrAuthors();
 
-  const repositories = selectedRepositories.map(r => ({ owner: r.owner, name: r.name }));
+  const repositories = prRepositories.map(r => ({ owner: r.owner, name: r.name }));
 
   return useQuery({
     queryKey: ["pullRequests", repositories, authors],

--- a/src/Wrangler.App/src/routes/pull-requests/-hooks/useUserSearch.ts
+++ b/src/Wrangler.App/src/routes/pull-requests/-hooks/useUserSearch.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import { useDebounce } from "use-debounce";
+import { client } from "../../../api/client.gen";
+
+export interface UserSearchResult {
+  login: string;
+  name?: string | null;
+  avatarUrl?: string | null;
+}
+
+const MIN_QUERY_LENGTH = 2;
+
+/**
+ * Debounced GitHub-user search for the PR author typeahead (issue #143).
+ *
+ * Called through the shared generated axios `client` (same baseURL/credentials
+ * as the generated SDK) rather than a generated `getUsersSearch`, because
+ * `npm run generate` is currently broken by the TypeScript 7 bump on main
+ * (@hey-api/openapi-ts is incompatible with TS 7). Switch to the generated SDK
+ * function once client generation is restored.
+ */
+export const useUserSearch = (query: string) => {
+  const [debounced] = useDebounce(query.trim(), 300);
+  const enabled = debounced.length >= MIN_QUERY_LENGTH;
+
+  return useQuery({
+    queryKey: ["userSearch", debounced],
+    queryFn: async () => {
+      const result = await client.get<UserSearchResult[], unknown, false>({
+        url: "/users/search",
+        query: { q: debounced },
+      });
+      return result.data ?? [];
+    },
+    enabled,
+    staleTime: 60 * 1000,
+  });
+};


### PR DESCRIPTION
## Summary

Closes #143. Two independent changes to the Pull Requests view, as separate commits.

### Part A — Independent PR repository scope
The PR view reused the workflow dashboard's "selected repositories". It now has its own scope:
- New `usePrRepositories` hook (new `"prRepositories"` localStorage key, same react-query pattern as `usePrAuthors`, so edits refetch). **Seeded** from the dashboard selection on first use, then fully independent.
- Consumed in `usePullRequests` in place of `useSelectedRepositories`.
- Inline repository multi-select (moo-ds `ComboBox`, fed by the full accessible repo list from `GET /repositories`) at the top of the PR controls.
- Dropped the settings-oriented `NoRepositories` guard for an inline empty state.

### Part B — Debounced GitHub-user author typeahead
Replaces the free-text author input:
- **New backend endpoint** `GET /users/search?q=` (`UserSearchHandler` + `UserSearchService`) wrapping Octokit `Search.SearchUsers`, projecting `{ login, name, avatarUrl }`, cached per query, and returning an empty list on rate-limit rather than erroring.
- `useUserSearch` hook — ≥2 chars, 300ms debounce.
- The author control keeps its input + chips and adds a suggestions dropdown (avatar + login). **Typing an exact login + Enter still works**, so bots like `dependabot[bot]`/`renovate[bot]` (the defaults) remain addable.

## ⚠️ Discovered: `npm run generate` is broken on `main`
The TypeScript 7 bump on `main` broke client generation — `@hey-api/openapi-ts` only supports TS `>=5.5.3 || >=6.0.0` and crashes on TS 7 (`Cannot read properties of undefined (reading 'AnyKeyword')`). So I could **not** regenerate the API client for the new endpoint. Instead `useUserSearch` calls the endpoint through the shared axios `client` (same baseURL/credentials) with a local type; `openapi-v1.json` is updated so the client is ready to regenerate once the toolchain is fixed. **This is worth its own issue** — happy to file it.

## Verification
- Frontend `npm run build` and backend `dotnet build` both pass; the new endpoint + `UserSearchResult` schema are in `openapi-v1.json`.
- _Not driven in the live app (needs an authenticated GitHub session)._ The author typeahead's live behaviour (suggestions, rate-limit fallback) in particular would benefit from a manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)