### PR TITLE
Filter the attention feed by type (#146)

### DIFF
--- a/src/Wrangler.App/package-lock.json
+++ b/src/Wrangler.App/package-lock.json
@@ -8,9 +8,9 @@
       "name": "wrangler",
       "version": "0.0.0",
       "dependencies": {
-        "@andrewmclachlan/moo-app": "^5.2.46",
-        "@andrewmclachlan/moo-ds": "^5.2.46",
-        "@andrewmclachlan/moo-icons": "^5.2.46",
+        "@andrewmclachlan/moo-app": "^5.2.56",
+        "@andrewmclachlan/moo-ds": "^5.2.56",
+        "@andrewmclachlan/moo-icons": "^5.2.56",
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-router": "^1.170.17",
         "@tanstack/react-router-devtools": "^1.167.0",
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-app": {
-      "version": "5.2.46",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.46/fc18fd8c3833c95c0f588ad46c1e0ce3a77a2d2d",
-      "integrity": "sha512-5GuEuiRwW66VYZwegPJh/G3XkR7WoVNgiFy5llaNPSQ3f4zoOSf271KgGdYFnxRuI00hDpiO/d+pq9dDPI3CGg==",
+      "version": "5.2.56",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.56/baef7891a9bd8b3e38f52028cb722feff522b003",
+      "integrity": "sha512-sI5ZyiRe8pip9RDRuYOdP4cWef1NMxiOgT1ZcfCYFc0yvP7ZNJ2gPQ4YU4bTpp3kQ3IjRR1Sl4/izgX49yj9cw==",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^5.17.0",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-ds": {
-      "version": "5.2.46",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.46/613a4f684b616558e40ecd137664075058cfd0c3",
-      "integrity": "sha512-wBSsWMgJYjN+3HuDPH1+9dEFJPqOHPtJgP880iyjlx/GP9SOWZA9I0s+PCNCI6nqLhnCb3nyOmgWDm5HT/1yGw==",
+      "version": "5.2.56",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.56/25699e7ff2f3f4b6d79a1ff1fa5381ff8ac45d0e",
+      "integrity": "sha512-0Kan5HZCgd2E3/d9JPU6Op1ZfdWXPMZJxORFWl5cWUh1AjCUnGGCl5+qPCpHMPKiteLb2U8J2MM2M5yB2ityrQ==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-table": "^8.21.0",
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-icons": {
-      "version": "5.2.46",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.46/5fece8d43661e44c49acc421ebad48ea28f89ea6",
-      "integrity": "sha512-dr3TYrHZxhKt/2SQIP41FUn9jP8yXx9N5vAoQRdFyNUgv48khxdwnxe6ln7rde8pmlFB0P2IKFw9N9Ao5MLnWw==",
+      "version": "5.2.56",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.56/7c637eb03718f17a0f9bcc44baebc05d5f7a4ee2",
+      "integrity": "sha512-mCq0wfSNel2RKrVneKplwYEE7RW3QkQTa0vtFOM1zYJTrc3V/nn6caOURPCgndLFOQGMADd2Zin+FZBUgPEl7w==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.7",

--- a/src/Wrangler.App/package.json
+++ b/src/Wrangler.App/package.json
@@ -13,9 +13,9 @@
     "update-moo": "npm install @andrewmclachlan/moo-app@latest @andrewmclachlan/moo-ds@latest @andrewmclachlan/moo-icons@latest"
   },
   "dependencies": {
-    "@andrewmclachlan/moo-app": "^5.2.46",
-    "@andrewmclachlan/moo-ds": "^5.2.46",
-    "@andrewmclachlan/moo-icons": "^5.2.46",
+    "@andrewmclachlan/moo-app": "^5.2.56",
+    "@andrewmclachlan/moo-ds": "^5.2.56",
+    "@andrewmclachlan/moo-icons": "^5.2.56",
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.17",
     "@tanstack/react-router-devtools": "^1.167.0",

--- a/src/Wrangler.App/src/css/components/attention.css
+++ b/src/Wrangler.App/src/css/components/attention.css
@@ -14,6 +14,60 @@
     margin: 0;
   }
 
+  /* Category filter (issue #146): toggle chips to narrow the feed, e.g. to just
+     "Review requested". Empty selection shows everything. */
+  .attention-filters {
+    display: flex;
+    gap: 0.375rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .attention-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: transparent;
+    color: rgba(255, 255, 255, 0.55);
+    font-size: 0.78rem;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.04);
+      color: rgba(255, 255, 255, 0.85);
+    }
+
+    &.active {
+      background: rgba(255, 255, 255, 0.08);
+      border-color: rgba(255, 255, 255, 0.28);
+      color: #fff;
+    }
+  }
+
+  .attention-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    opacity: 0.35;
+    transition: opacity 0.15s;
+
+    &.red { background: #ff6b6b; }
+    &.amber { background: #e8c44a; }
+  }
+
+  .attention-chip:hover .attention-dot {
+    opacity: 0.7;
+  }
+
+  .attention-chip.active .attention-dot {
+    opacity: 1;
+  }
+
   .attention-list {
     list-style: none;
     margin: 0;

--- a/src/Wrangler.App/src/routes/attention/-components/Attention.tsx
+++ b/src/Wrangler.App/src/routes/attention/-components/Attention.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from "react";
 import { DateTime } from "luxon";
 import { useAttention } from "../-hooks/useAttention";
+import { useAttentionTypeFilter } from "../-hooks/useAttentionTypeFilter";
 import { useSelectedRepositories } from "../../settings/-hooks/useSelectedRepositories";
 import { NoRepositories } from "../../../components/NoRepositories";
 import { Spinner } from "../../../components/Spinner";
@@ -17,6 +19,8 @@ const TYPE_CLASS: Record<AttentionItemType, string> = {
   PullRequestReview: "amber",
 };
 
+const TYPE_OPTIONS: AttentionItemType[] = ["WorkflowFailure", "PullRequestReview"];
+
 const itemKey = (item: AttentionItem) =>
   `${item.type}:${item.repositoryOwner}/${item.repositoryName}:${item.workflowRunId ?? item.pullRequestNumber ?? item.title}`;
 
@@ -28,6 +32,20 @@ const formatWhen = (iso: string): string => {
 export const Attention = () => {
   const { data: selectedRepositories } = useSelectedRepositories();
   const { data: items, isLoading, isError, error } = useAttention();
+  const [typeFilter, setTypeFilter] = useAttentionTypeFilter();
+
+  const typeSet = useMemo(() => new Set(typeFilter), [typeFilter]);
+  const toggleType = (type: AttentionItemType) => {
+    const next = new Set(typeSet);
+    if (next.has(type)) next.delete(type);
+    else next.add(type);
+    setTypeFilter([...next]);
+  };
+
+  const visibleItems = useMemo(
+    () => (items ?? []).filter((item) => typeSet.size === 0 || typeSet.has(item.type)),
+    [items, typeSet],
+  );
 
   if (!selectedRepositories || selectedRepositories.length === 0) {
     return <NoRepositories />;
@@ -38,19 +56,42 @@ export const Attention = () => {
     return <p>Error loading attention feed.</p>;
   }
 
+  const hasItems = !!items && items.length > 0;
+
   return (
     <article className="attention">
       <h2>Needs your attention</h2>
 
+      {hasItems && (
+        <div className="attention-filters" role="group" aria-label="Filter by type">
+          {TYPE_OPTIONS.map((type) => (
+            <button
+              key={type}
+              type="button"
+              className={`attention-chip${typeSet.has(type) ? " active" : ""}`}
+              aria-pressed={typeSet.has(type)}
+              onClick={() => toggleType(type)}
+            >
+              <span className={`attention-dot ${TYPE_CLASS[type]}`} />
+              {TYPE_LABEL[type]}
+            </button>
+          ))}
+        </div>
+      )}
+
       {isLoading && <Spinner />}
 
-      {!isLoading && (!items || items.length === 0) && (
+      {!isLoading && !hasItems && (
         <p className="attention-empty">Nothing is waiting on you across your selected repositories. ✨</p>
       )}
 
-      {items && items.length > 0 && (
+      {hasItems && visibleItems.length === 0 && (
+        <p className="attention-empty">No items match the current filter.</p>
+      )}
+
+      {visibleItems.length > 0 && (
         <ul className="attention-list">
-          {items.map((item) => (
+          {visibleItems.map((item) => (
             <li key={itemKey(item)} className="attention-item">
               <span className={`attention-badge ${TYPE_CLASS[item.type]}`}>{TYPE_LABEL[item.type]}</span>
               <div className="attention-body">

--- a/src/Wrangler.App/src/routes/attention/-hooks/useAttentionTypeFilter.ts
+++ b/src/Wrangler.App/src/routes/attention/-hooks/useAttentionTypeFilter.ts
@@ -1,0 +1,10 @@
+import { useLocalStorage } from "@andrewmclachlan/moo-ds";
+import type { AttentionItemType } from "../../../api";
+
+/**
+ * The attention item types to show in the feed. An empty array means "show
+ * everything" (the default); otherwise only the selected types are shown — e.g.
+ * select "PullRequestReview" for a focused "awaiting my review" cut (issue #146).
+ */
+export const useAttentionTypeFilter = () =>
+  useLocalStorage<AttentionItemType[]>("attentionTypeFilter", []);


### PR DESCRIPTION
## Summary

Closes #146. A focused "PRs awaiting my review" cut.

The signal already exists: the attention feed (from #144) surfaces PRs where you're a requested reviewer as **"Review requested"** items (`AttentionService.GetPullRequestReviewsAsync`). They were just interleaved with workflow failures and not filterable on their own.

This adds a lightweight **category filter** to the attention view:
- Toggle chips ("Workflow failed" / "Review requested"), mirroring the PR status-chip idiom, with the same red/amber dot cues.
- Empty selection shows everything; selecting "Review requested" gives the focused awaiting-my-review cut.
- Persisted via `useLocalStorage` (`"attentionTypeFilter"`), so the choice survives reloads.
- Empty-filter-result state: "No items match the current filter."

Frontend-only — no backend change, no client regeneration.

## Verification

- `npm run build` passes.
- _Not driven in the live app (needs an authenticated GitHub session);_ the filter logic is a straightforward client-side `type` membership check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)