### PR TITLE
Surface security & Dependabot alerts in the attention feed (#145)

### DIFF
--- a/src/Wrangler.Api/Handlers/LoginHandler.cs
+++ b/src/Wrangler.Api/Handlers/LoginHandler.cs
@@ -23,7 +23,11 @@ public static class LoginHandler
             ["client_id"] = clientId,
             ["redirect_uri"] = redirectUri,
             ["state"] = state,
-            ["scope"] = "read:user repo"
+            // security_events is required to read code scanning alerts on
+            // private repos (issue #145); Dependabot and secret scanning alerts
+            // are covered by repo. Existing sessions keep their old scope until
+            // the user next logs in and re-consents.
+            ["scope"] = "read:user repo security_events"
         };
         url.Query = String.Join('&', query.Select(kvp => $"{kvp.Key}={Uri.EscapeDataString(kvp.Value)}"));
 

--- a/src/Wrangler.Api/Models/Attention/AttentionItem.cs
+++ b/src/Wrangler.Api/Models/Attention/AttentionItem.cs
@@ -9,6 +9,8 @@ public enum AttentionItemType
     WorkflowFailure,
     /// <summary>A pull request where the current user is a requested reviewer.</summary>
     PullRequestReview,
+    /// <summary>Open security alerts (Dependabot, code scanning, or secret scanning) on a repository.</summary>
+    SecurityAlert,
 }
 
 /// <summary>
@@ -36,4 +38,13 @@ public record AttentionItem
 
     public int? PullRequestNumber { get; init; }
     public string? PullRequestAuthor { get; init; }
+
+    /// <summary>The number of open alerts (SecurityAlert items only).</summary>
+    public int? AlertCount { get; init; }
+
+    /// <summary>The highest alert severity: critical | high | medium | low (SecurityAlert items only).</summary>
+    public string? AlertSeverity { get; init; }
+
+    /// <summary>The alert category: Dependabot, Code scanning, or Secret scanning (SecurityAlert items only).</summary>
+    public string? AlertCategory { get; init; }
 }

--- a/src/Wrangler.Api/Models/Security/SecurityAlertResponses.cs
+++ b/src/Wrangler.Api/Models/Security/SecurityAlertResponses.cs
@@ -1,0 +1,46 @@
+namespace Asm.Wrangler.Api.Models.Security;
+
+// Minimal shapes of GitHub's security alert REST payloads. Octokit 14 has no
+// typed clients for these endpoints, so we deserialize the snake_case JSON onto
+// these PascalCase records via Octokit's serializer (same approach as
+// PendingDeploymentResponse). Only the fields we actually need are declared.
+
+/// <summary>A Dependabot alert (subset of fields).</summary>
+public record DependabotAlertResponse
+{
+    public string? State { get; init; }
+    public DependabotSecurityAdvisory? SecurityAdvisory { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
+}
+
+/// <summary>The advisory attached to a Dependabot alert.</summary>
+public record DependabotSecurityAdvisory
+{
+    /// <summary>low | medium | high | critical.</summary>
+    public string? Severity { get; init; }
+}
+
+/// <summary>A code scanning alert (subset of fields).</summary>
+public record CodeScanningAlertResponse
+{
+    public string? State { get; init; }
+    public CodeScanningRule? Rule { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
+}
+
+/// <summary>The rule that raised a code scanning alert.</summary>
+public record CodeScanningRule
+{
+    /// <summary>low | medium | high | critical (when a security severity is assigned).</summary>
+    public string? SecuritySeverityLevel { get; init; }
+
+    /// <summary>Fallback rule severity: error | warning | note.</summary>
+    public string? Severity { get; init; }
+}
+
+/// <summary>A secret scanning alert (subset of fields). Secrets carry no severity.</summary>
+public record SecretScanningAlertResponse
+{
+    public string? State { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
+}

--- a/src/Wrangler.Api/Models/Security/SecurityAlertSummary.cs
+++ b/src/Wrangler.Api/Models/Security/SecurityAlertSummary.cs
@@ -1,0 +1,23 @@
+namespace Asm.Wrangler.Api.Models.Security;
+
+/// <summary>
+/// A per-repository, per-category summary of open security alerts, used to
+/// surface a "you have N alerts" signal without listing every individual alert.
+/// </summary>
+public record SecurityAlertSummary
+{
+    /// <summary>The alert category: "Dependabot", "Code scanning", or "Secret scanning".</summary>
+    public required string Category { get; init; }
+
+    /// <summary>The number of open alerts in this category.</summary>
+    public required int Count { get; init; }
+
+    /// <summary>The highest severity among the open alerts: critical | high | medium | low.</summary>
+    public required string HighestSeverity { get; init; }
+
+    /// <summary>When the most recently updated open alert changed.</summary>
+    public required DateTimeOffset NewestAt { get; init; }
+
+    /// <summary>The repository's GitHub security page for this category.</summary>
+    public required string HtmlUrl { get; init; }
+}

--- a/src/Wrangler.Api/Program.cs
+++ b/src/Wrangler.Api/Program.cs
@@ -72,6 +72,7 @@ static void AddServices(WebApplicationBuilder builder)
     builder.Services.AddScoped<ISettingsService, SettingsService>();
     builder.Services.AddScoped<IPullRequestService, PullRequestService>();
     builder.Services.AddScoped<IAttentionService, AttentionService>();
+    builder.Services.AddScoped<ISecurityAlertsService, SecurityAlertsService>();
     builder.Services.AddScoped<IGateService, GateService>();
     builder.Services.AddScoped<IUserSearchService, UserSearchService>();
     builder.Services.AddSingleton<ICacheKeyService, CacheKeyService>();

--- a/src/Wrangler.Api/Services/AttentionService.cs
+++ b/src/Wrangler.Api/Services/AttentionService.cs
@@ -15,6 +15,7 @@ public interface IAttentionService
 
 internal class AttentionService(
     IGitHubClient gitHubClient,
+    ISecurityAlertsService securityAlertsService,
     IHttpContextAccessor httpContextAccessor,
     IDistributedCache cache,
     ILogger<AttentionService> logger) : GitHubService(cache, logger), IAttentionService
@@ -51,10 +52,29 @@ internal class AttentionService(
 
         var workflowTask = GetWorkflowFailuresAsync(owner, repo, repository.DefaultBranch, cancellationToken);
         var reviewTask = GetPullRequestReviewsAsync(owner, repo, currentUser, cancellationToken);
+        var securityTask = GetSecurityAlertsAsync(owner, repo, cancellationToken);
 
-        await Task.WhenAll(workflowTask, reviewTask);
+        await Task.WhenAll(workflowTask, reviewTask, securityTask);
 
-        return workflowTask.Result.Concat(reviewTask.Result);
+        return workflowTask.Result.Concat(reviewTask.Result).Concat(securityTask.Result);
+    }
+
+    private async Task<IEnumerable<AttentionItem>> GetSecurityAlertsAsync(string owner, string repo, CancellationToken cancellationToken)
+    {
+        var summaries = await securityAlertsService.GetOpenAlertSummariesAsync(owner, repo, cancellationToken);
+
+        return summaries.Select(summary => new AttentionItem
+        {
+            Type = AttentionItemType.SecurityAlert,
+            RepositoryOwner = owner,
+            RepositoryName = repo,
+            Title = $"{summary.Count} open {summary.Category} alert{(summary.Count == 1 ? "" : "s")}",
+            HtmlUrl = summary.HtmlUrl,
+            OccurredAt = summary.NewestAt,
+            AlertCount = summary.Count,
+            AlertSeverity = summary.HighestSeverity,
+            AlertCategory = summary.Category,
+        });
     }
 
     private async Task<IEnumerable<AttentionItem>> GetWorkflowFailuresAsync(string owner, string repo, string defaultBranch, CancellationToken cancellationToken)

--- a/src/Wrangler.Api/Services/SecurityAlertsService.cs
+++ b/src/Wrangler.Api/Services/SecurityAlertsService.cs
@@ -1,0 +1,151 @@
+using Asm.Wrangler.Api.Models.Security;
+using Microsoft.Extensions.Caching.Distributed;
+using Octokit;
+
+namespace Asm.Wrangler.Api.Services;
+
+/// <summary>
+/// Reads open security alerts (Dependabot, code scanning, secret scanning) for a
+/// repository and reduces them to per-category summaries (issue #145).
+/// </summary>
+public interface ISecurityAlertsService
+{
+    /// <summary>
+    /// Returns a summary per alert category that has open alerts. Categories that
+    /// are disabled, inaccessible, or unsupported by the current token are omitted.
+    /// </summary>
+    Task<IEnumerable<SecurityAlertSummary>> GetOpenAlertSummariesAsync(string owner, string repo, CancellationToken cancellationToken);
+}
+
+internal class SecurityAlertsService(IGitHubClient gitHubClient, IDistributedCache cache, ICacheKeyService cacheKeyService, ILogger<SecurityAlertsService> logger)
+    : GitHubService(cache, logger), ISecurityAlertsService
+{
+    private readonly SemaphoreSlim _gate = new(8);
+
+    private static readonly IReadOnlyDictionary<string, int> SeverityRank = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["critical"] = 4,
+        ["high"] = 3,
+        ["medium"] = 2,
+        ["moderate"] = 2,
+        ["low"] = 1,
+    };
+
+    public async Task<IEnumerable<SecurityAlertSummary>> GetOpenAlertSummariesAsync(string owner, string repo, CancellationToken cancellationToken)
+    {
+        var cacheKey = cacheKeyService.GetCacheKey($"gh:security-alerts:{owner}/{repo}");
+
+        var cached = await TryGetFromCache<SecurityAlertSummary>(cacheKey, cancellationToken);
+        if (cached != null)
+        {
+            return cached;
+        }
+
+        var summaries = new List<SecurityAlertSummary>();
+
+        var dependabot = await GetDependabotSummaryAsync(owner, repo, cancellationToken);
+        if (dependabot != null) summaries.Add(dependabot);
+
+        var codeScanning = await GetCodeScanningSummaryAsync(owner, repo, cancellationToken);
+        if (codeScanning != null) summaries.Add(codeScanning);
+
+        var secretScanning = await GetSecretScanningSummaryAsync(owner, repo, cancellationToken);
+        if (secretScanning != null) summaries.Add(secretScanning);
+
+        await TryCache(cacheKey, summaries, cancellationToken);
+
+        return summaries;
+    }
+
+    private async Task<SecurityAlertSummary?> GetDependabotSummaryAsync(string owner, string repo, CancellationToken cancellationToken)
+    {
+        var alerts = await GetAlertsAsync<DependabotAlertResponse>($"repos/{owner}/{repo}/dependabot/alerts", cancellationToken);
+        if (alerts.Length == 0) return null;
+
+        return new SecurityAlertSummary
+        {
+            Category = "Dependabot",
+            Count = alerts.Length,
+            HighestSeverity = HighestSeverity(alerts.Select(a => a.SecurityAdvisory?.Severity)),
+            NewestAt = alerts.Max(a => a.UpdatedAt),
+            HtmlUrl = $"https://github.com/{owner}/{repo}/security/dependabot",
+        };
+    }
+
+    private async Task<SecurityAlertSummary?> GetCodeScanningSummaryAsync(string owner, string repo, CancellationToken cancellationToken)
+    {
+        var alerts = await GetAlertsAsync<CodeScanningAlertResponse>($"repos/{owner}/{repo}/code-scanning/alerts", cancellationToken);
+        if (alerts.Length == 0) return null;
+
+        return new SecurityAlertSummary
+        {
+            Category = "Code scanning",
+            Count = alerts.Length,
+            HighestSeverity = HighestSeverity(alerts.Select(a => a.Rule?.SecuritySeverityLevel)),
+            NewestAt = alerts.Max(a => a.UpdatedAt),
+            HtmlUrl = $"https://github.com/{owner}/{repo}/security/code-scanning",
+        };
+    }
+
+    private async Task<SecurityAlertSummary?> GetSecretScanningSummaryAsync(string owner, string repo, CancellationToken cancellationToken)
+    {
+        var alerts = await GetAlertsAsync<SecretScanningAlertResponse>($"repos/{owner}/{repo}/secret-scanning/alerts", cancellationToken);
+        if (alerts.Length == 0) return null;
+
+        return new SecurityAlertSummary
+        {
+            Category = "Secret scanning",
+            // Secret scanning alerts carry no severity; an exposed secret is
+            // serious, so surface it as "high".
+            Count = alerts.Length,
+            HighestSeverity = "high",
+            NewestAt = alerts.Max(a => a.UpdatedAt),
+            HtmlUrl = $"https://github.com/{owner}/{repo}/security/secret-scanning",
+        };
+    }
+
+    private async Task<T[]> GetAlertsAsync<T>(string path, CancellationToken cancellationToken)
+    {
+        await _gate.WaitAsync(cancellationToken);
+        try
+        {
+            await Jitter(cancellationToken);
+            var parameters = new Dictionary<string, string> { ["state"] = "open", ["per_page"] = "100" };
+            var response = await OctoCall(() => gitHubClient.Connection.Get<T[]>(
+                new Uri(path, UriKind.Relative), parameters, null, cancellationToken), cancellationToken);
+            return response.Body ?? [];
+        }
+        catch (NotFoundException)
+        {
+            // The feature is disabled for this repo, or the repo isn't accessible.
+            return [];
+        }
+        catch (ForbiddenException)
+        {
+            // Insufficient scope (e.g. code scanning on a private repo without
+            // security_events) or access — degrade quietly rather than failing
+            // the whole attention feed.
+            logger.LogDebug("Security alert read forbidden for {Path}; skipping category.", path);
+            return [];
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private static string HighestSeverity(IEnumerable<string?> severities)
+    {
+        string? best = null;
+        var bestRank = 0;
+        foreach (var severity in severities)
+        {
+            if (severity != null && SeverityRank.TryGetValue(severity, out var rank) && rank > bestRank)
+            {
+                bestRank = rank;
+                best = severity.ToLowerInvariant();
+            }
+        }
+        return best ?? "low";
+    }
+}

--- a/src/Wrangler.Api/openapi-v1.json
+++ b/src/Wrangler.Api/openapi-v1.json
@@ -589,13 +589,35 @@
               "null",
               "string"
             ]
+          },
+          "alertCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "alertSeverity": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "alertCategory": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "AttentionItemType": {
         "enum": [
           "WorkflowFailure",
-          "PullRequestReview"
+          "PullRequestReview",
+          "SecurityAlert"
         ]
       },
       "AttentionRequest": {

--- a/src/Wrangler.App/package-lock.json
+++ b/src/Wrangler.App/package-lock.json
@@ -8,9 +8,9 @@
       "name": "wrangler",
       "version": "0.0.0",
       "dependencies": {
-        "@andrewmclachlan/moo-app": "^5.2.46",
-        "@andrewmclachlan/moo-ds": "^5.2.46",
-        "@andrewmclachlan/moo-icons": "^5.2.46",
+        "@andrewmclachlan/moo-app": "^5.2.56",
+        "@andrewmclachlan/moo-ds": "^5.2.56",
+        "@andrewmclachlan/moo-icons": "^5.2.56",
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-router": "^1.170.17",
         "@tanstack/react-router-devtools": "^1.167.0",
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-app": {
-      "version": "5.2.46",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.46/fc18fd8c3833c95c0f588ad46c1e0ce3a77a2d2d",
-      "integrity": "sha512-5GuEuiRwW66VYZwegPJh/G3XkR7WoVNgiFy5llaNPSQ3f4zoOSf271KgGdYFnxRuI00hDpiO/d+pq9dDPI3CGg==",
+      "version": "5.2.56",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.56/baef7891a9bd8b3e38f52028cb722feff522b003",
+      "integrity": "sha512-sI5ZyiRe8pip9RDRuYOdP4cWef1NMxiOgT1ZcfCYFc0yvP7ZNJ2gPQ4YU4bTpp3kQ3IjRR1Sl4/izgX49yj9cw==",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-browser": "^5.17.0",
@@ -72,9 +72,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-ds": {
-      "version": "5.2.46",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.46/613a4f684b616558e40ecd137664075058cfd0c3",
-      "integrity": "sha512-wBSsWMgJYjN+3HuDPH1+9dEFJPqOHPtJgP880iyjlx/GP9SOWZA9I0s+PCNCI6nqLhnCb3nyOmgWDm5HT/1yGw==",
+      "version": "5.2.56",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.56/25699e7ff2f3f4b6d79a1ff1fa5381ff8ac45d0e",
+      "integrity": "sha512-0Kan5HZCgd2E3/d9JPU6Op1ZfdWXPMZJxORFWl5cWUh1AjCUnGGCl5+qPCpHMPKiteLb2U8J2MM2M5yB2ityrQ==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-table": "^8.21.0",
@@ -95,9 +95,9 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-icons": {
-      "version": "5.2.46",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.46/5fece8d43661e44c49acc421ebad48ea28f89ea6",
-      "integrity": "sha512-dr3TYrHZxhKt/2SQIP41FUn9jP8yXx9N5vAoQRdFyNUgv48khxdwnxe6ln7rde8pmlFB0P2IKFw9N9Ao5MLnWw==",
+      "version": "5.2.56",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.56/7c637eb03718f17a0f9bcc44baebc05d5f7a4ee2",
+      "integrity": "sha512-mCq0wfSNel2RKrVneKplwYEE7RW3QkQTa0vtFOM1zYJTrc3V/nn6caOURPCgndLFOQGMADd2Zin+FZBUgPEl7w==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.7",

--- a/src/Wrangler.App/package.json
+++ b/src/Wrangler.App/package.json
@@ -13,9 +13,9 @@
     "update-moo": "npm install @andrewmclachlan/moo-app@latest @andrewmclachlan/moo-ds@latest @andrewmclachlan/moo-icons@latest"
   },
   "dependencies": {
-    "@andrewmclachlan/moo-app": "^5.2.46",
-    "@andrewmclachlan/moo-ds": "^5.2.46",
-    "@andrewmclachlan/moo-icons": "^5.2.46",
+    "@andrewmclachlan/moo-app": "^5.2.56",
+    "@andrewmclachlan/moo-ds": "^5.2.56",
+    "@andrewmclachlan/moo-icons": "^5.2.56",
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.17",
     "@tanstack/react-router-devtools": "^1.167.0",

--- a/src/Wrangler.App/src/api/types.gen.ts
+++ b/src/Wrangler.App/src/api/types.gen.ts
@@ -48,9 +48,12 @@ export type AttentionItem = {
   branch?: null | string;
   pullRequestNumber?: null | number | string;
   pullRequestAuthor?: null | string;
+  alertCount?: null | number | string;
+  alertSeverity?: null | string;
+  alertCategory?: null | string;
 };
 
-export type AttentionItemType = 'WorkflowFailure' | 'PullRequestReview';
+export type AttentionItemType = 'WorkflowFailure' | 'PullRequestReview' | 'SecurityAlert';
 
 export type AttentionRequest = {
   repositories?: Array<RepositoryRequest>;

--- a/src/Wrangler.App/src/css/components/attention.css
+++ b/src/Wrangler.App/src/css/components/attention.css
@@ -58,6 +58,7 @@
 
     &.red { background: #ff6b6b; }
     &.amber { background: #e8c44a; }
+    &.purple { background: #b98cf0; }
   }
 
   .attention-chip:hover .attention-dot {
@@ -109,6 +110,11 @@
     &.amber {
       background: rgba(255, 191, 0, 0.12);
       color: #e8c44a;
+    }
+
+    &.grey {
+      background: rgba(255, 255, 255, 0.08);
+      color: rgba(255, 255, 255, 0.6);
     }
   }
 

--- a/src/Wrangler.App/src/css/components/attention.css
+++ b/src/Wrangler.App/src/css/components/attention.css
@@ -14,6 +14,60 @@
     margin: 0;
   }
 
+  /* Category filter (issue #146): toggle chips to narrow the feed, e.g. to just
+     "Review requested". Empty selection shows everything. */
+  .attention-filters {
+    display: flex;
+    gap: 0.375rem;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .attention-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: transparent;
+    color: rgba(255, 255, 255, 0.55);
+    font-size: 0.78rem;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.04);
+      color: rgba(255, 255, 255, 0.85);
+    }
+
+    &.active {
+      background: rgba(255, 255, 255, 0.08);
+      border-color: rgba(255, 255, 255, 0.28);
+      color: #fff;
+    }
+  }
+
+  .attention-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    opacity: 0.35;
+    transition: opacity 0.15s;
+
+    &.red { background: #ff6b6b; }
+    &.amber { background: #e8c44a; }
+  }
+
+  .attention-chip:hover .attention-dot {
+    opacity: 0.7;
+  }
+
+  .attention-chip.active .attention-dot {
+    opacity: 1;
+  }
+
   .attention-list {
     list-style: none;
     margin: 0;

--- a/src/Wrangler.App/src/routes/attention/-components/Attention.tsx
+++ b/src/Wrangler.App/src/routes/attention/-components/Attention.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from "react";
 import { DateTime } from "luxon";
 import { useAttention } from "../-hooks/useAttention";
+import { useAttentionTypeFilter } from "../-hooks/useAttentionTypeFilter";
 import { useSelectedRepositories } from "../../settings/-hooks/useSelectedRepositories";
 import { NoRepositories } from "../../../components/NoRepositories";
 import { Spinner } from "../../../components/Spinner";
@@ -17,6 +19,8 @@ const TYPE_CLASS: Record<AttentionItemType, string> = {
   PullRequestReview: "amber",
 };
 
+const TYPE_OPTIONS: AttentionItemType[] = ["WorkflowFailure", "PullRequestReview"];
+
 const itemKey = (item: AttentionItem) =>
   `${item.type}:${item.repositoryOwner}/${item.repositoryName}:${item.workflowRunId ?? item.pullRequestNumber ?? item.title}`;
 
@@ -28,6 +32,20 @@ const formatWhen = (iso: string): string => {
 export const Attention = () => {
   const { data: selectedRepositories } = useSelectedRepositories();
   const { data: items, isLoading, isError, error } = useAttention();
+  const [typeFilter, setTypeFilter] = useAttentionTypeFilter();
+
+  const typeSet = useMemo(() => new Set(typeFilter), [typeFilter]);
+  const toggleType = (type: AttentionItemType) => {
+    const next = new Set(typeSet);
+    if (next.has(type)) next.delete(type);
+    else next.add(type);
+    setTypeFilter([...next]);
+  };
+
+  const visibleItems = useMemo(
+    () => (items ?? []).filter((item) => typeSet.size === 0 || typeSet.has(item.type)),
+    [items, typeSet],
+  );
 
   if (!selectedRepositories || selectedRepositories.length === 0) {
     return <NoRepositories />;
@@ -38,19 +56,42 @@ export const Attention = () => {
     return <p>Error loading attention feed.</p>;
   }
 
+  const hasItems = !!items && items.length > 0;
+
   return (
     <article className="attention">
       <h2>Needs your attention</h2>
 
+      {hasItems && (
+        <div className="attention-filters" role="group" aria-label="Filter by type">
+          {TYPE_OPTIONS.map((type) => (
+            <button
+              key={type}
+              type="button"
+              className={`attention-chip${typeSet.has(type) ? " active" : ""}`}
+              aria-pressed={typeSet.has(type)}
+              onClick={() => toggleType(type)}
+            >
+              <span className={`attention-dot ${TYPE_CLASS[type]}`} />
+              {TYPE_LABEL[type]}
+            </button>
+          ))}
+        </div>
+      )}
+
       {isLoading && <Spinner />}
 
-      {!isLoading && (!items || items.length === 0) && (
+      {!isLoading && !hasItems && (
         <p className="attention-empty">Nothing is waiting on you across your selected repositories. ✨</p>
       )}
 
-      {items && items.length > 0 && (
+      {hasItems && visibleItems.length === 0 && (
+        <p className="attention-empty">No items match the current filter.</p>
+      )}
+
+      {visibleItems.length > 0 && (
         <ul className="attention-list">
-          {items.map((item) => (
+          {visibleItems.map((item) => (
             <li key={itemKey(item)} className="attention-item">
               <span className={`attention-badge ${TYPE_CLASS[item.type]}`}>{TYPE_LABEL[item.type]}</span>
               <div className="attention-body">

--- a/src/Wrangler.App/src/routes/attention/-components/Attention.tsx
+++ b/src/Wrangler.App/src/routes/attention/-components/Attention.tsx
@@ -12,17 +12,42 @@ const formatter = new Intl.RelativeTimeFormat(navigator.language, { style: "long
 const TYPE_LABEL: Record<AttentionItemType, string> = {
   WorkflowFailure: "Workflow failed",
   PullRequestReview: "Review requested",
+  SecurityAlert: "Security alert",
 };
 
+// Class used for the filter-chip dot per type. Security-alert item badges are
+// coloured by severity instead (see badgeClass).
 const TYPE_CLASS: Record<AttentionItemType, string> = {
   WorkflowFailure: "red",
   PullRequestReview: "amber",
+  SecurityAlert: "purple",
 };
 
-const TYPE_OPTIONS: AttentionItemType[] = ["WorkflowFailure", "PullRequestReview"];
+const TYPE_OPTIONS: AttentionItemType[] = ["WorkflowFailure", "PullRequestReview", "SecurityAlert"];
+
+const SEVERITY_CLASS: Record<string, string> = {
+  critical: "red",
+  high: "red",
+  medium: "amber",
+  moderate: "amber",
+  low: "grey",
+};
+
+const capitalise = (value: string) => value.charAt(0).toUpperCase() + value.slice(1);
+
+// Security items badge on severity; other types badge on their fixed colour.
+const badgeClass = (item: AttentionItem): string =>
+  item.type === "SecurityAlert"
+    ? SEVERITY_CLASS[(item.alertSeverity ?? "").toLowerCase()] ?? "amber"
+    : TYPE_CLASS[item.type];
+
+const badgeLabel = (item: AttentionItem): string =>
+  item.type === "SecurityAlert"
+    ? (item.alertSeverity ? capitalise(item.alertSeverity) : "Security")
+    : TYPE_LABEL[item.type];
 
 const itemKey = (item: AttentionItem) =>
-  `${item.type}:${item.repositoryOwner}/${item.repositoryName}:${item.workflowRunId ?? item.pullRequestNumber ?? item.title}`;
+  `${item.type}:${item.repositoryOwner}/${item.repositoryName}:${item.workflowRunId ?? item.pullRequestNumber ?? item.alertCategory ?? item.title}`;
 
 const formatWhen = (iso: string): string => {
   const dt = DateTime.fromISO(iso);
@@ -93,7 +118,7 @@ export const Attention = () => {
         <ul className="attention-list">
           {visibleItems.map((item) => (
             <li key={itemKey(item)} className="attention-item">
-              <span className={`attention-badge ${TYPE_CLASS[item.type]}`}>{TYPE_LABEL[item.type]}</span>
+              <span className={`attention-badge ${badgeClass(item)}`}>{badgeLabel(item)}</span>
               <div className="attention-body">
                 <a className="attention-title" href={item.htmlUrl} target="_blank" rel="noopener noreferrer">
                   {item.title}
@@ -107,6 +132,9 @@ export const Attention = () => {
                     <span className="attention-pr">
                       #{item.pullRequestNumber}{item.pullRequestAuthor ? ` · ${item.pullRequestAuthor}` : ""}
                     </span>
+                  )}
+                  {item.type === "SecurityAlert" && item.alertCategory && (
+                    <span className="attention-alert">{item.alertCategory}</span>
                   )}
                 </div>
               </div>

--- a/src/Wrangler.App/src/routes/attention/-hooks/useAttentionTypeFilter.ts
+++ b/src/Wrangler.App/src/routes/attention/-hooks/useAttentionTypeFilter.ts
@@ -1,0 +1,10 @@
+import { useLocalStorage } from "@andrewmclachlan/moo-ds";
+import type { AttentionItemType } from "../../../api";
+
+/**
+ * The attention item types to show in the feed. An empty array means "show
+ * everything" (the default); otherwise only the selected types are shown — e.g.
+ * select "PullRequestReview" for a focused "awaiting my review" cut (issue #146).
+ */
+export const useAttentionTypeFilter = () =>
+  useLocalStorage<AttentionItemType[]>("attentionTypeFilter", []);


### PR DESCRIPTION
## Summary

Closes #145. Aggregates open **Dependabot**, **code scanning**, and **secret scanning** alerts across selected repos and surfaces them in the "needs your attention" feed as a per repo+category **severity summary**.

## Backend
- **`SecurityAlertsService`** reads the three alert REST endpoints via raw `Connection.Get<T>` (Octokit 14 has no typed clients — same pattern as `GateService`/`PendingDeploymentResponse`), reduces each to `{ category, count, highestSeverity, newestAt }`, caches per repo (30 min), gated at 8 concurrent, and swallows 403/404 per category (feature disabled / no access / missing scope).
- **`AttentionService`** emits a `SecurityAlert` item per repo+category, linking to that repo's GitHub security page. New `AttentionItem` fields (`AlertCount`, `AlertSeverity`, `AlertCategory`) + enum value.
- **`LoginHandler`** requests the `security_events` scope (required for code scanning on **private** repos; Dependabot + secret scanning work with the existing `repo` scope). **Soft rollout** — existing sessions keep their current token until the user next logs in and re-consents; until then private-repo code-scanning reads 403 and are swallowed. _(You mentioned you'll handle the GitHub-side app permissions.)_

## Frontend
- Attention view renders security items (severity-coloured badge: critical/high→red, medium→amber, low→grey; category in the meta line). The #146 type filter gains a **Security alert** chip.
- Client regenerated for the new `AttentionItem` fields + enum.

## Stacking & verification notes
- **Stacked on #146** (PR #193) — this PR includes #146's attention-filter commit until that merges, then narrows automatically.
- Verified: backend `dotnet build` ✓, frontend `tsc -b` ✓ (typecheck), client regenerated ✓.
- ⚠️ I could **not** run the local vite bundle build: the `openapi-ts@next` toolchain (from #192) leaves `main` hard to install locally — `npm install` fails on `@hey-api/client-axios`'s `openapi-ts <2` peer vs the `0.0.0-next` prerelease, and `--legacy-peer-deps` then skips moo's **peer** deps (fortawesome, react-hook-form, …), breaking the bundle. `npm ci` from the committed lockfile installs them correctly (as CI does), so CI should bundle fine — my local failure was a corrupted `node_modules` plus a Windows file-lock. **This install fragility is a real `main`-wide toolchain issue worth folding into #191** (e.g. declare moo's peers directly, or resolve the client-axios peer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)