### PR TITLE
Label dashboard branch filter 'Default branch'

### DIFF
--- a/src/Wrangler.App/src/routes/dashboard/-components/shared/Filters.tsx
+++ b/src/Wrangler.App/src/routes/dashboard/-components/shared/Filters.tsx
@@ -56,7 +56,7 @@ export const Filters = () => {
     <div className="filter-bar">
       <ComboBox<BranchOption>
         className="filter-combo"
-        placeholder="All branches"
+        placeholder="Default branch"
         multiSelect
         clearable
         creatable


### PR DESCRIPTION
## Summary

The dashboard branch filter's empty state was labelled **"All branches"**, which was misleading. An empty filter doesn't show all branches — `DashboardService.GetWorkflowsAsync` already falls back to each repository's **default branch** (`repo.DefaultBranch`) when `BranchFilters` is empty. It only *looked* pinned to `main` because that's the default branch.

This changes the placeholder to **"Default branch"**, mirroring GitHub's wording. **No behaviour change** — the backend already did the right thing.

The Gates page filter keeps "All branches" because it's a client-side filter over already-loaded gates, where empty genuinely means no branch constraint.

## Testing
Frontend builds green. One-line, display-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)