### PR TITLE
Return to the previous screen after login

### DIFF
--- a/src/Wrangler.Api/Authentication/SessionKeys.cs
+++ b/src/Wrangler.Api/Authentication/SessionKeys.cs
@@ -26,4 +26,7 @@ public static class SessionKeys
 
     /// <summary>The anti-forgery state value for an in-progress OAuth flow.</summary>
     public const string OAuthState = "oauth_state";
+
+    /// <summary>Local path to return the user to after a successful login (set when login was triggered mid-session).</summary>
+    public const string PostLoginReturnUrl = "post_login_return_url";
 }

--- a/src/Wrangler.Api/Endpoints/CallbackHandler.cs
+++ b/src/Wrangler.Api/Endpoints/CallbackHandler.cs
@@ -89,7 +89,11 @@ public static class CallbackHandler
         http.Session.SetString(SessionKeys.User, login ?? "unknown");
         if (!String.IsNullOrEmpty(avatarUrl)) http.Session.SetString(SessionKeys.AvatarUrl, avatarUrl);
 
-        return Results.Redirect("/dashboard");
+        // Return the user to where login was triggered (validated as a safe local path), or the
+        // dashboard when there was no such screen (e.g. an explicit sign-in from the landing page).
+        var returnUrl = http.Session.GetString(SessionKeys.PostLoginReturnUrl);
+        http.Session.Remove(SessionKeys.PostLoginReturnUrl);
+        return Results.Redirect(ReturnUrl.ResolveOrFallback(returnUrl));
     }
 
     private static int? ParseSeconds(IDictionary<string, string> tokenData, string key) =>

--- a/src/Wrangler.Api/Endpoints/LoginHandler.cs
+++ b/src/Wrangler.Api/Endpoints/LoginHandler.cs
@@ -1,4 +1,6 @@
-﻿namespace Asm.Wrangler.Api.Endpoints;
+﻿using Asm.Wrangler.Api.Authentication;
+
+namespace Asm.Wrangler.Api.Endpoints;
 
 /// <summary>
 /// Handles the GitHub OAuth login flow by redirecting the user to GitHub's authorisation page.
@@ -15,7 +17,15 @@ public static class LoginHandler
 
         // Always generate a fresh state to avoid stale values from previous flows.
         var state = Guid.NewGuid().ToString("N");
-        http.Session.SetString("oauth_state", state);
+        http.Session.SetString(SessionKeys.OAuthState, state);
+
+        // Remember where the user was so the callback can return them there. Only a safe local path is
+        // stored; any stale value from a previous flow is cleared so a plain sign-in still lands home.
+        var returnUrl = http.Request.Query["returnUrl"].ToString();
+        if (ReturnUrl.IsLocalPath(returnUrl))
+            http.Session.SetString(SessionKeys.PostLoginReturnUrl, returnUrl);
+        else
+            http.Session.Remove(SessionKeys.PostLoginReturnUrl);
 
         var url = new UriBuilder("https://github.com/login/oauth/authorize");
         var query = new Dictionary<string, string>

--- a/src/Wrangler.Api/Endpoints/ReturnUrl.cs
+++ b/src/Wrangler.Api/Endpoints/ReturnUrl.cs
@@ -1,0 +1,36 @@
+namespace Asm.Wrangler.Api.Endpoints;
+
+/// <summary>
+/// Validates and resolves the post-login return URL. The value originates from a query string, so it
+/// is untrusted: only same-site relative paths are honoured, to prevent an open-redirect through the
+/// login flow.
+/// </summary>
+internal static class ReturnUrl
+{
+    /// <summary>The destination used when no valid return URL is supplied.</summary>
+    public const string Fallback = "/dashboard";
+
+    /// <summary>Returns <paramref name="returnUrl"/> if it is a safe local path, otherwise <see cref="Fallback"/>.</summary>
+    public static string ResolveOrFallback(string? returnUrl) =>
+        IsLocalPath(returnUrl) ? returnUrl! : Fallback;
+
+    /// <summary>
+    /// True only for a same-site relative path (e.g. "/pull-requests", "/gates?author=x"). Rejects
+    /// absolute URLs, protocol-relative ("//host") and backslash ("/\host") forms, and the auth/api
+    /// surface (loop guard).
+    /// </summary>
+    public static bool IsLocalPath(string? url)
+    {
+        if (String.IsNullOrEmpty(url)) return false;
+
+        // Must be rooted, and must not be protocol-relative or a backslash trick that browsers treat
+        // as an absolute URL ("//evil.com", "/\evil.com").
+        if (url[0] != '/') return false;
+        if (url.Length > 1 && (url[1] == '/' || url[1] == '\\')) return false;
+
+        // Don't bounce back into the auth or API surface — that risks a redirect loop.
+        return !url.StartsWith("/login", StringComparison.OrdinalIgnoreCase)
+            && !url.StartsWith("/callback", StringComparison.OrdinalIgnoreCase)
+            && !url.StartsWith("/api", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Wrangler.App/src/utils/axiosInterceptors.ts
+++ b/src/Wrangler.App/src/utils/axiosInterceptors.ts
@@ -27,8 +27,10 @@ export const configureInterceptors = () => {
       // Handle 401 Unauthorized errors
       if (error.response?.status === 401) {
 
-        // Redirect to login
-        window.location.href = '/login/github';
+        // Redirect to login, remembering the current screen so the callback can return here
+        // instead of always landing on the dashboard.
+        const returnUrl = window.location.pathname + window.location.search;
+        window.location.href = `/login/github?returnUrl=${encodeURIComponent(returnUrl)}`;
       }
 
       // Re-throw the error so it can still be handled by individual components if needed

--- a/tests/Wrangler.Tests/ReturnUrlTests.cs
+++ b/tests/Wrangler.Tests/ReturnUrlTests.cs
@@ -1,0 +1,33 @@
+using Asm.Wrangler.Api.Endpoints;
+using Xunit;
+
+namespace Wrangler.Tests;
+
+public class ReturnUrlTests
+{
+    [Theory]
+    [InlineData("/pull-requests")]
+    [InlineData("/gates?author=octocat")]
+    [InlineData("/attention")]
+    [InlineData("/settings/repositories")]
+    public void ResolveOrFallback_keeps_safe_local_paths(string url)
+    {
+        Assert.Equal(url, ReturnUrl.ResolveOrFallback(url));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("pull-requests")]              // not rooted
+    [InlineData("//evil.com")]                 // protocol-relative
+    [InlineData("/\\evil.com")]                // backslash trick
+    [InlineData("https://evil.com")]           // absolute URL
+    [InlineData("http://evil.com/path")]       // absolute URL
+    [InlineData("/login/github")]              // auth surface (loop guard)
+    [InlineData("/callback/github")]           // auth surface (loop guard)
+    [InlineData("/api/workflows")]             // api surface (loop guard)
+    public void ResolveOrFallback_falls_back_to_dashboard_for_unsafe_or_missing(string? url)
+    {
+        Assert.Equal("/dashboard", ReturnUrl.ResolveOrFallback(url));
+    }
+}


### PR DESCRIPTION
## Summary

When a session lapses mid-use, login always dumped you back on the **dashboard**, losing your place. Now the login flow returns you to the screen you were on.

- The 401 interceptor (`axiosInterceptors.ts`) redirects to `/login/github?returnUrl=<current path>` instead of bare `/login/github`.
- `LoginHandler` validates and stashes the return URL in the session; `CallbackHandler` redirects there after a successful exchange, **falling back to `/dashboard`** when there's none.
- Explicit sign-ins (landing-page button, installed-PWA root) still land on the dashboard — there's no prior screen there.

## Security

`returnUrl` comes from the query string, so it's untrusted. `ReturnUrl.IsLocalPath` honours **only same-site relative paths** — rejecting absolute URLs, protocol-relative (`//host`), backslash tricks (`/\host`), and the `/login`/`/callback`/`/api` surface (loop guard). Anything else falls back to `/dashboard`. This prevents an open redirect through the login flow.

## Testing

14 new unit tests for the validator (safe paths preserved; unsafe/missing → dashboard). Backend 105/105, frontend builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)