### PR TITLE
Harden webhook processing so transient failures don't disable the webhook

### DIFF
--- a/src/Wrangler.Api/Webhooks/GitHubWebhookEventProcessor.cs
+++ b/src/Wrangler.Api/Webhooks/GitHubWebhookEventProcessor.cs
@@ -33,6 +33,28 @@ internal sealed class GitHubWebhookEventProcessor(
         PullRequestAction.ReadyForReview,
     ];
 
+    /// <summary>
+    /// Wraps the per-event dispatch so a transient backend failure — for example Redis being briefly
+    /// unavailable in the delivery-dedupe (<see cref="ClaimAsync"/>) or the cache-version bump — never
+    /// bubbles a 5xx back to GitHub. GitHub auto-disables a webhook after a run of failed deliveries, so
+    /// we log the failure and acknowledge the delivery (200) instead; the client's polling/refetch is the
+    /// backstop for the missed update. Signature validation and deserialisation happen upstream of this
+    /// method and still reject genuinely bad deliveries.
+    /// </summary>
+    public override async ValueTask ProcessWebhookAsync(WebhookHeaders headers, WebhookEvent webhookEvent, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await base.ProcessWebhookAsync(headers, webhookEvent, cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogError(ex,
+                "Webhook processing failed for delivery {DeliveryId} (event {Event}); acknowledging to keep the webhook enabled.",
+                headers.Delivery, headers.Event);
+        }
+    }
+
     protected override async ValueTask ProcessWorkflowRunWebhookAsync(WebhookHeaders headers, WorkflowRunEvent workflowRunEvent, WorkflowRunAction action, CancellationToken cancellationToken = default)
     {
         if (!await ClaimAsync(headers, cancellationToken)) return;

--- a/tests/Wrangler.Tests/WebhookProcessingResilienceTests.cs
+++ b/tests/Wrangler.Tests/WebhookProcessingResilienceTests.cs
@@ -1,0 +1,121 @@
+using System.Runtime.CompilerServices;
+using Asm.Wrangler.Api.Models;
+using Asm.Wrangler.Api.Webhooks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Octokit.Webhooks;
+using Octokit.Webhooks.Events;
+using Octokit.Webhooks.Events.WorkflowRun;
+using Octokit.Webhooks.Models;
+using Xunit;
+
+namespace Wrangler.Tests;
+
+/// <summary>
+/// The webhook processor must acknowledge deliveries (return without throwing) even when a backend
+/// dependency fails transiently, so a brief outage can't rack up failures and get GitHub to auto-disable
+/// the webhook. The processor dispatches on <c>ProcessWebhookAsync(WebhookHeaders, WebhookEvent, ...)</c>,
+/// which is exercised here directly (the event models have no public constructor and enforce required
+/// JSON properties, so they're built uninitialised rather than deserialised).
+/// </summary>
+public class WebhookProcessingResilienceTests
+{
+    private static readonly WebhookHeaders Headers = new() { Event = "workflow_run", Delivery = "delivery-1" };
+
+    [Fact]
+    public async Task Delivery_is_acknowledged_when_dedupe_backend_throws()
+    {
+        var broadcaster = new RecordingBroadcaster();
+        var processor = Processor(
+            claim: () => throw new InvalidOperationException("redis unavailable"),
+            broadcaster: broadcaster);
+
+        // Must NOT throw — a throw would surface as a 5xx to GitHub and count as a failed delivery.
+        await processor.ProcessWebhookAsync(Headers, WorkflowRunEvent(withRepo: false));
+
+        Assert.False(broadcaster.Published);
+    }
+
+    [Fact]
+    public async Task Delivery_is_acknowledged_when_version_bump_throws()
+    {
+        var broadcaster = new RecordingBroadcaster();
+        var processor = Processor(
+            claim: () => true,
+            bump: () => throw new InvalidOperationException("redis unavailable"),
+            broadcaster: broadcaster);
+
+        await processor.ProcessWebhookAsync(Headers, WorkflowRunEvent(withRepo: true));
+
+        Assert.False(broadcaster.Published);
+    }
+
+    [Fact]
+    public async Task Delivery_broadcasts_normally_when_backend_is_healthy()
+    {
+        var broadcaster = new RecordingBroadcaster();
+        var processor = Processor(claim: () => true, broadcaster: broadcaster);
+
+        await processor.ProcessWebhookAsync(Headers, WorkflowRunEvent(withRepo: true));
+
+        Assert.True(broadcaster.Published);
+    }
+
+    private static GitHubWebhookEventProcessor Processor(Func<bool> claim, Func<bool>? bump = null, RecordingBroadcaster? broadcaster = null) =>
+        new(new FakeRegistry(claim), new FakeVersions(bump), broadcaster ?? new RecordingBroadcaster(),
+            NullLogger<GitHubWebhookEventProcessor>.Instance);
+
+    // WorkflowRunEvent is abstract (one concrete subclass per action, with Action fixed); build the
+    // concrete "completed" event uninitialised and set only the members the handler reads — once past the
+    // dedupe claim, the repo and run ids.
+    private static WorkflowRunEvent WorkflowRunEvent(bool withRepo)
+    {
+        var evt = New<WorkflowRunCompletedEvent>();
+        if (withRepo)
+        {
+            var owner = New<User>();
+            Set(owner, "Login", "owner");
+            var repo = New<Repository>();
+            Set(repo, "Name", "repo");
+            Set(repo, "Owner", owner);
+            Set(evt, "Repository", repo);
+
+            var run = New<WorkflowRun>();
+            Set(run, "Id", 10L);
+            Set(run, "WorkflowId", 20L);
+            Set(evt, "WorkflowRun", run);
+        }
+        return evt;
+    }
+
+    private static T New<T>() => (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
+    private static void Set(object target, string property, object value) =>
+        target.GetType().GetProperty(property)!.SetValue(target, value);
+
+    private sealed class FakeRegistry(Func<bool> claim) : IInstallationRegistry
+    {
+        public Task<bool> TryClaimDeliveryAsync(string deliveryId, CancellationToken cancellationToken) => Task.FromResult(claim());
+        public Task SaveInstallationAsync(long installationId, InstallationInfo info, IEnumerable<string> repos, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task RemoveInstallationAsync(long installationId, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task SetSuspendedAsync(long installationId, bool suspended, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task AddRepositoriesAsync(long installationId, IEnumerable<string> repos, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task RemoveRepositoriesAsync(long installationId, IEnumerable<string> repos, CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<long?> GetInstallationIdForRepoAsync(string owner, string repo, CancellationToken cancellationToken) => Task.FromResult<long?>(null);
+    }
+
+    private sealed class FakeVersions(Func<bool>? bump) : IRepoVersionService
+    {
+        public Task<long> GetVersionAsync(string owner, string repo, RepoDataKind kind, CancellationToken cancellationToken) => Task.FromResult(0L);
+        public Task BumpAsync(string owner, string repo, RepoDataKind kind, CancellationToken cancellationToken)
+        {
+            bump?.Invoke();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingBroadcaster : IEventBroadcaster
+    {
+        public bool Published { get; private set; }
+        public void Publish(GitHubEvent evt) => Published = true;
+        public EventSubscription Subscribe() => throw new NotSupportedException("The processor never subscribes.");
+    }
+}


### PR DESCRIPTION
## Summary

GitHub **auto-disables a webhook after a run of failed deliveries**. Previously, a transient backend hiccup — Redis briefly unavailable in the delivery-dedupe claim (`TryClaimDeliveryAsync`) or the cache-version bump (`BumpAsync`) — would throw out of the webhook processor and surface as a **5xx** to GitHub. A short outage could therefore rack up failures and get the webhook disabled, which then silently stops all event delivery (and SSE with it).

This overrides the processor's dispatcher, `ProcessWebhookAsync(WebhookHeaders, WebhookEvent, …)`, to catch processing failures, log them (with delivery id + event), and **still acknowledge the delivery (200)**.

## Scope / safety

- Signature validation and payload deserialisation happen **upstream** of this method, so genuinely bad/unsigned deliveries are still rejected — we only swallow *our* processing failures.
- `OperationCanceledException` is **not** swallowed (cooperative cancellation / shutdown isn't a processing failure).
- The missed update is backstopped by the client's normal polling/refetch.

## Testing

3 new unit tests drive the dispatcher directly (the event models are abstract with no public ctor, so they're built uninitialised): delivery is acknowledged when the dedupe backend throws, acknowledged when the version bump throws, and broadcasts normally when healthy. Backend **108/108**.

## Note

This is defensive hardening — it was **not** the cause of the recent outage (that was the App's event subscriptions being unchecked, so GitHub had nothing to deliver). It prevents a *future* transient failure from disabling the webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)