### PR TITLE
Authorize SSE events per user (fix cross-user metadata disclosure)

### DIFF
--- a/src/Wrangler.Api/Endpoints/EventStreamHandler.cs
+++ b/src/Wrangler.Api/Endpoints/EventStreamHandler.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Asm.Wrangler.Api.Services;
 using Asm.Wrangler.Api.Webhooks;
 using Microsoft.AspNetCore.Http.Features;
 
@@ -12,7 +13,10 @@ public static class EventStreamHandler
     private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(25);
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
 
-    public static async Task Handle(HttpContext http, IEventBroadcaster broadcaster, CancellationToken cancellationToken)
+    // Taking IRepositoryAccessService (which depends on the user's IGitHubClient) also makes this
+    // endpoint reject anonymous connections: resolving IGitHubClient throws when there's no session
+    // token, which the exception handler turns into a 401 before streaming starts.
+    public static async Task Handle(HttpContext http, IEventBroadcaster broadcaster, IRepositoryAccessService access, CancellationToken cancellationToken)
     {
         // Kestrel-level buffering defence; X-Accel-Buffering only signals the
         // reverse proxy (App Service front-end / nginx) and won't stop Kestrel
@@ -49,6 +53,12 @@ public static class EventStreamHandler
                 if (!await readTask) break;
                 while (subscription.Reader.TryRead(out var evt))
                 {
+                    // Authorization gate: only forward events for repositories this user can actually
+                    // see. Events are fanned out to every subscriber, so without this a user would
+                    // receive activity metadata (repo names, PR/run ids) for repos they have no access
+                    // to. Fails closed — a repo the user can't access (or a failed check) is dropped.
+                    if (!await access.CanAccessAsync(evt.Owner, evt.Repo, cancellationToken)) continue;
+
                     var payload = JsonSerializer.Serialize(evt, JsonOptions);
                     await http.Response.WriteAsync($"event: {evt.Type}\ndata: {payload}\n\n", cancellationToken);
                     await http.Response.Body.FlushAsync(cancellationToken);

--- a/src/Wrangler.Api/Program.cs
+++ b/src/Wrangler.Api/Program.cs
@@ -84,6 +84,7 @@ static void AddServices(WebApplicationBuilder builder)
     builder.Services.AddScoped<ISecurityAlertsService, SecurityAlertsService>();
     builder.Services.AddScoped<IGateService, GateService>();
     builder.Services.AddScoped<IUserSearchService, UserSearchService>();
+    builder.Services.AddScoped<IRepositoryAccessService, RepositoryAccessService>();
 
     // Postie CQRS: scans this assembly for IQueryHandler/ICommandHandler implementations
     // and wires the endpoint dispatcher used by MapQuery/MapCommand.

--- a/src/Wrangler.Api/Services/RepositoryAccessService.cs
+++ b/src/Wrangler.Api/Services/RepositoryAccessService.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Octokit;
+
+namespace Asm.Wrangler.Api.Services;
+
+/// <summary>
+/// Answers whether the current user's GitHub token can access a repository. Used to gate the SSE event
+/// stream so a user is never sent webhook events for repositories they cannot see. Results are cached
+/// per user (the cache key includes the user's token) for a short window.
+/// </summary>
+public interface IRepositoryAccessService
+{
+    /// <summary>True if the current user's token can read <paramref name="owner"/>/<paramref name="repo"/>.</summary>
+    Task<bool> CanAccessAsync(string owner, string repo, CancellationToken cancellationToken);
+}
+
+internal sealed class RepositoryAccessService(
+    IGitHubClient client,
+    IDistributedCache cache,
+    ICacheKeyService cacheKeyService,
+    ILogger<RepositoryAccessService> logger) : IRepositoryAccessService
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromMinutes(5);
+
+    public async Task<bool> CanAccessAsync(string owner, string repo, CancellationToken cancellationToken)
+    {
+        // Keyed per user (ICacheKeyService folds in the caller's token), so one user's access decision
+        // is never reused for another.
+        var cacheKey = cacheKeyService.GetCacheKey($"repoaccess:{owner}/{repo}");
+
+        var cached = await TryReadCacheAsync(cacheKey, cancellationToken);
+        if (cached is not null) return cached.Value;
+
+        bool canAccess;
+        try
+        {
+            // GitHub returns 404 (not 403) for a private repo the user can't see, so it doesn't leak the
+            // repo's existence; Octokit surfaces that as NotFoundException.
+            await client.Repository.Get(owner, repo);
+            canAccess = true;
+        }
+        catch (Octokit.NotFoundException)
+        {
+            canAccess = false;
+        }
+        catch (Octokit.ForbiddenException)
+        {
+            canAccess = false;
+        }
+        catch (Exception ex)
+        {
+            // Transient failure (rate limit, network). Fail closed for this event, but don't cache the
+            // denial so a blip doesn't suppress the user's events for the whole TTL.
+            logger.LogWarning(ex, "Repository access check failed for {Owner}/{Repo}; denying this event.", owner, repo);
+            return false;
+        }
+
+        await TryWriteCacheAsync(cacheKey, canAccess, cancellationToken);
+        return canAccess;
+    }
+
+    private async Task<bool?> TryReadCacheAsync(string cacheKey, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var cached = await cache.GetStringAsync(cacheKey, cancellationToken);
+            return cached is null ? null : cached == "1";
+        }
+        catch (Exception ex) when (ex is StackExchange.Redis.RedisException or InvalidOperationException)
+        {
+            // Cache unavailable — fall back to a live check.
+            return null;
+        }
+    }
+
+    private async Task TryWriteCacheAsync(string cacheKey, bool canAccess, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await cache.SetStringAsync(cacheKey, canAccess ? "1" : "0",
+                new DistributedCacheEntryOptions { AbsoluteExpirationRelativeToNow = CacheTtl }, cancellationToken);
+        }
+        catch (Exception ex) when (ex is StackExchange.Redis.RedisException or InvalidOperationException)
+        {
+            // Caching is best-effort.
+        }
+    }
+}

--- a/tests/Wrangler.Tests/RepositoryAccessServiceTests.cs
+++ b/tests/Wrangler.Tests/RepositoryAccessServiceTests.cs
@@ -1,0 +1,96 @@
+using System.Net;
+using System.Text;
+using Asm.Wrangler.Api.Services;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging.Abstractions;
+using Octokit;
+using Octokit.Internal;
+using Xunit;
+
+namespace Wrangler.Tests;
+
+public class RepositoryAccessServiceTests
+{
+    [Fact]
+    public async Task Returns_true_and_caches_when_repo_is_accessible()
+    {
+        var handler = new StubHandler(_ => Json(HttpStatusCode.OK,
+            """{"id":1,"name":"repo","full_name":"owner/repo","owner":{"login":"owner","id":1}}"""));
+        var cache = new FakeCache();
+        var service = Service(handler, cache);
+
+        Assert.True(await service.CanAccessAsync("owner", "repo", CancellationToken.None));
+        Assert.Equal("1", await cache.GetStringAsync("u:repoaccess:owner/repo"));
+    }
+
+    [Fact]
+    public async Task Returns_false_and_caches_when_repo_is_not_accessible()
+    {
+        // GitHub returns 404 for a private repo the user can't see.
+        var handler = new StubHandler(_ => Json(HttpStatusCode.NotFound, """{"message":"Not Found"}"""));
+        var cache = new FakeCache();
+        var service = Service(handler, cache);
+
+        Assert.False(await service.CanAccessAsync("owner", "repo", CancellationToken.None));
+        Assert.Equal("0", await cache.GetStringAsync("u:repoaccess:owner/repo"));
+    }
+
+    [Fact]
+    public async Task Uses_cached_decision_without_calling_github()
+    {
+        var handler = new StubHandler(_ => throw new InvalidOperationException("GitHub must not be called on a cache hit."));
+        var cache = new FakeCache();
+        await cache.SetStringAsync("u:repoaccess:owner/repo", "1");
+        var service = Service(handler, cache);
+
+        Assert.True(await service.CanAccessAsync("owner", "repo", CancellationToken.None));
+        Assert.Equal(0, handler.Calls);
+    }
+
+    private static RepositoryAccessService Service(StubHandler handler, IDistributedCache cache)
+    {
+        var connection = new Connection(new ProductHeaderValue("wrangler-tests"), new HttpClientAdapter(() => handler));
+        return new RepositoryAccessService(new GitHubClient(connection), cache, new FakeCacheKeys(), NullLogger<RepositoryAccessService>.Instance);
+    }
+
+    private static HttpResponseMessage Json(HttpStatusCode status, string json) =>
+        new(status) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    private sealed class FakeCacheKeys : ICacheKeyService
+    {
+        public string GetCacheKey(string key) => "u:" + key;
+    }
+
+    private sealed class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> responder) : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            return Task.FromResult(responder(request));
+        }
+    }
+
+    private sealed class FakeCache : IDistributedCache
+    {
+        private readonly Dictionary<string, byte[]> _store = new();
+
+        public byte[]? Get(string key) => _store.TryGetValue(key, out var v) ? v : null;
+        public Task<byte[]?> GetAsync(string key, CancellationToken token = default) => Task.FromResult(Get(key));
+        public void Set(string key, byte[] value, DistributedCacheEntryOptions options) => _store[key] = value;
+        public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+        {
+            _store[key] = value;
+            return Task.CompletedTask;
+        }
+        public void Refresh(string key) { }
+        public Task RefreshAsync(string key, CancellationToken token = default) => Task.CompletedTask;
+        public void Remove(string key) => _store.Remove(key);
+        public Task RemoveAsync(string key, CancellationToken token = default)
+        {
+            _store.Remove(key);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

**Security fix.** The webhook event broadcast (`EventBroadcaster.Publish`) fanned **every** event out to **every** connected SSE client with no authorization. Any signed-in user therefore received activity metadata — repository names, PR numbers, workflow/run ids — for repositories in orgs they aren't even members of. That's a cross-user information disclosure.

## Fix

Gate each SSE connection at its output boundary: before forwarding an event, verify the connection's user can actually access the event's repo, and drop it otherwise.

- New `IRepositoryAccessService.CanAccessAsync(owner, repo)` — checks the user's token can `GET` the repo (GitHub returns 404 for repos you can't see). **Cached per user** (`ICacheKeyService` folds in the token) for 5 minutes, so it's lazy — only repos that actually emit events get checked, once per TTL.
- `EventStreamHandler` filters each event through it; heartbeats stay unconditional.
- **Fails closed:** an inaccessible repo, a failed check, or an unauthenticated connection yields no events (the stream now also requires auth — resolving the user's `IGitHubClient` 401s anonymous connections).

Client-supplied repo *selection* was explicitly rejected as the boundary — it's client-side (localStorage) and trivially spoofable; authorization must be server-side, matching the data endpoints.

## Notes

- No frontend change and no wire-contract change (the stream is `ExcludeFromDescription`); clients simply receive only events they're entitled to.
- Implementation caught a real gotcha: an unqualified `NotFoundException` bound to a framework type shadowing `Octokit.NotFoundException`, so the catch is fully qualified.

## Testing

3 new unit tests (real `GitHubClient` over a stub handler): accessible repo → allowed + cached, inaccessible (404) → denied + cached, and a cache hit short-circuits without calling GitHub. Backend **108/108**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)