### PR TITLE
Stream follow-ups: shared PR-identity helper + periodic accessible-set refresh

### DIFF
--- a/src/Wrangler.Api/Endpoints/EventStreamHandler.cs
+++ b/src/Wrangler.Api/Endpoints/EventStreamHandler.cs
@@ -13,6 +13,12 @@ public static class EventStreamHandler
 {
     private static readonly TimeSpan HeartbeatInterval = TimeSpan.FromSeconds(25);
 
+    // SSE connections are long-lived, so re-resolve the accessible-repo set periodically rather than
+    // only at connect: a user who loses (or gains) repo access has it reflected within this window
+    // instead of only after a reconnect. GetAccessibleAsync is cached (~5 min), so this is a cache hit
+    // most of the time and a real resolve at most once per interval.
+    private static readonly TimeSpan AuthorizationRefreshInterval = TimeSpan.FromMinutes(5);
+
     // Taking ISubscriberAuthorization (which depends on the user's IGitHubClient) also makes this
     // endpoint reject anonymous connections: resolving IGitHubClient throws when there's no session
     // token, which the exception handler turns into a 401 before streaming starts.
@@ -35,9 +41,11 @@ public static class EventStreamHandler
         http.Response.Headers["X-Accel-Buffering"] = "no";
         http.Response.Headers.Connection = "keep-alive";
 
-        // Resolve the user's full accessible-repo set once at connect time (cached), so events are
-        // filtered in-memory below with zero per-event GitHub API calls.
+        // Resolve the user's full accessible-repo set at connect time (cached), so events are filtered
+        // in-memory below with zero per-event GitHub API calls. Re-resolved periodically (see the
+        // heartbeat branch) so access changes are picked up on long-lived connections.
         var accessible = await authorization.GetAccessibleAsync(cancellationToken);
+        var nextAuthorizationRefresh = DateTimeOffset.UtcNow + AuthorizationRefreshInterval;
 
         using var subscription = broadcaster.Subscribe();
         await http.Response.Body.FlushAsync(cancellationToken);
@@ -53,6 +61,15 @@ public static class EventStreamHandler
             if (winner == heartbeatTask)
             {
                 if (!await heartbeatTask) break;
+
+                // Refresh the accessible-repo set on the first heartbeat past the interval, so access
+                // revoked (or granted) mid-connection takes effect without requiring a reconnect.
+                if (DateTimeOffset.UtcNow >= nextAuthorizationRefresh)
+                {
+                    accessible = await authorization.GetAccessibleAsync(cancellationToken);
+                    nextAuthorizationRefresh = DateTimeOffset.UtcNow + AuthorizationRefreshInterval;
+                }
+
                 await http.Response.WriteAsync(": keepalive\n\n", cancellationToken);
                 await http.Response.Body.FlushAsync(cancellationToken);
                 heartbeatTask = heartbeat.WaitForNextTickAsync(cancellationToken).AsTask();

--- a/src/Wrangler.App/src/hooks/mergePullRequest.test.ts
+++ b/src/Wrangler.App/src/hooks/mergePullRequest.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mergePullRequest, removePullRequest, type PushedPullRequest } from "./mergePullRequest";
+import { mergePullRequest, removePullRequest, isSamePullRequest, type PushedPullRequest } from "./mergePullRequest";
 import type { PullRequestModel } from "../api";
 
 const makePr = (overrides: Partial<PullRequestModel> = {}): PullRequestModel => ({
@@ -36,6 +36,24 @@ const makePushed = (overrides: Partial<PushedPullRequest> = {}): PushedPullReque
   updatedAt: "2026-01-02T00:00:00Z",
   state: "open",
   ...overrides,
+});
+
+describe("isSamePullRequest", () => {
+  it("matches by id even when number/repo differ", () => {
+    expect(isSamePullRequest(makePr({ number: 99, repositoryName: "other" }), makePushed({ id: 1 }))).toBe(true);
+  });
+
+  it("matches by number + repository when ids differ", () => {
+    expect(isSamePullRequest(makePr({ id: 5 }), makePushed({ id: 7, number: 42 }))).toBe(true);
+  });
+
+  it("does not match the same number in a different repository", () => {
+    expect(isSamePullRequest(makePr({ id: 5, repositoryName: "widget" }), makePushed({ id: 7, number: 42, repositoryName: "gadget" }))).toBe(false);
+  });
+
+  it("is case-insensitive on owner/repo", () => {
+    expect(isSamePullRequest(makePr({ id: 5, repositoryOwner: "ACME", repositoryName: "Widget" }), makePushed({ id: 7, repositoryOwner: "acme", repositoryName: "widget" }))).toBe(true);
+  });
 });
 
 describe("mergePullRequest", () => {

--- a/src/Wrangler.App/src/hooks/mergePullRequest.ts
+++ b/src/Wrangler.App/src/hooks/mergePullRequest.ts
@@ -20,6 +20,17 @@ export interface PushedPullRequest {
   state: string;
 }
 
+// Identity match between a cached PR and a pushed webhook PR. Matches by id first,
+// falling back to number + repository (owner/name) because PullRequestModel's
+// id/number are typed `number | string` while the webhook always sends numbers.
+// Shared by the merge/remove helpers and the stream hook's "is it cached?" check
+// so the three don't drift apart.
+export const isSamePullRequest = (pr: PullRequestModel, pushed: PushedPullRequest): boolean =>
+  String(pr.id) === String(pushed.id)
+  || (String(pr.number) === String(pushed.number)
+    && pr.repositoryOwner.toLowerCase() === pushed.repositoryOwner.toLowerCase()
+    && pr.repositoryName.toLowerCase() === pushed.repositoryName.toLowerCase());
+
 // Pure merge of a pushed pull_request webhook event into the cached PR list,
 // so the PR table can reflect a live SSE update without a GitHub refetch.
 // Matches the cached PR by id first, falling back to number + repository
@@ -33,11 +44,7 @@ export const mergePullRequest = (
   prs: PullRequestModel[],
   pushed: PushedPullRequest,
 ): PullRequestModel[] => {
-  const index = prs.findIndex((pr) =>
-    String(pr.id) === String(pushed.id)
-    || (String(pr.number) === String(pushed.number)
-      && pr.repositoryOwner.toLowerCase() === pushed.repositoryOwner.toLowerCase()
-      && pr.repositoryName.toLowerCase() === pushed.repositoryName.toLowerCase()));
+  const index = prs.findIndex((pr) => isSamePullRequest(pr, pushed));
 
   if (index === -1) return prs;
 
@@ -68,11 +75,7 @@ export const removePullRequest = (
   prs: PullRequestModel[],
   pushed: PushedPullRequest,
 ): PullRequestModel[] => {
-  const index = prs.findIndex((pr) =>
-    String(pr.id) === String(pushed.id)
-    || (String(pr.number) === String(pushed.number)
-      && pr.repositoryOwner.toLowerCase() === pushed.repositoryOwner.toLowerCase()
-      && pr.repositoryName.toLowerCase() === pushed.repositoryName.toLowerCase()));
+  const index = prs.findIndex((pr) => isSamePullRequest(pr, pushed));
 
   if (index === -1) return prs;
 

--- a/src/Wrangler.App/src/hooks/useGitHubEventStream.ts
+++ b/src/Wrangler.App/src/hooks/useGitHubEventStream.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { mergeWorkflowRun, branchMatch } from "./mergeWorkflowRun";
-import { mergePullRequest, removePullRequest, type PushedPullRequest } from "./mergePullRequest";
+import { mergePullRequest, removePullRequest, isSamePullRequest, type PushedPullRequest } from "./mergePullRequest";
 import type { PullRequestModel, RepositoryModel, WorkflowRunModel } from "../api";
 
 interface GitHubEvent {
@@ -85,11 +85,7 @@ export const useGitHubEventStream = (enabled: boolean = true) => {
         .findAll({ queryKey: ["pullRequests"] })
         .some((query) => {
           const data = query.state.data as PullRequestModel[] | undefined;
-          return Array.isArray(data) && data.some((pr) =>
-            String(pr.id) === String(pushed.id)
-            || (String(pr.number) === String(pushed.number)
-              && pr.repositoryOwner.toLowerCase() === pushed.repositoryOwner.toLowerCase()
-              && pr.repositoryName.toLowerCase() === pushed.repositoryName.toLowerCase()));
+          return Array.isArray(data) && data.some((pr) => isSamePullRequest(pr, pushed));
         });
 
       if (isCached) {


### PR DESCRIPTION
## Summary

The two follow-ups flagged on #215:

1. **Extract `isSamePullRequest`** — the PR-identity predicate (match by id, or number + repository, case-insensitive) was duplicated across `mergePullRequest`, `removePullRequest`, and the stream hook's "is it cached?" check. Now a single shared, tested helper so the three can't drift apart. Behavior-preserving refactor.

2. **Periodic accessible-set refresh** — `EventStreamHandler` resolved the accessible-repo set once at connect and reused it for the whole (long-lived) connection, so a user who lost repo access kept receiving that repo's events until they reconnected. It now re-resolves on the heartbeat every ~5 min. `GetAccessibleAsync` is cached (~5 min TTL), so this is a cache hit most of the time and at most one real resolve per interval — no meaningful quota cost.

## Testing

4 new unit tests for `isSamePullRequest` (id match, number+repo match, same-number-different-repo non-match, case-insensitivity). Backend **116/116**, frontend **52/52**, lint 0 errors, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)