### PR TITLE
Prune selected repos GitHub no longer lists (fix renamed-repo duplicates)

### DIFF
--- a/src/Wrangler.App/src/App.tsx
+++ b/src/Wrangler.App/src/App.tsx
@@ -3,6 +3,7 @@ import { TanStackRouterDevtools } from '@tanstack/react-router-devtools'
 import { Notifications } from '@andrewmclachlan/moo-ds'
 import { Layout } from './layout/Layout'
 import { useGitHubEventStream } from './hooks/useGitHubEventStream'
+import { useReconcileSelectedRepositories } from './hooks/useReconcileSelectedRepositories'
 
 function App() {
 
@@ -10,6 +11,9 @@ function App() {
   const isStandalone = pathname === "/" || pathname === "/privacy";
 
   useGitHubEventStream(!isStandalone);
+  // Drop selected repos GitHub no longer lists (renamed/removed) so they stop
+  // producing stale, duplicate items everywhere.
+  useReconcileSelectedRepositories();
 
   if (isStandalone) {
     return (

--- a/src/Wrangler.App/src/hooks/useReconcileSelectedRepositories.ts
+++ b/src/Wrangler.App/src/hooks/useReconcileSelectedRepositories.ts
@@ -1,0 +1,31 @@
+import { useEffect } from "react";
+import { useRepositories } from "./useRepositories";
+import { useSelectedRepositories, useUpdateSelectedRepositories } from "../routes/settings/-hooks/useSelectedRepositories";
+import { pruneSelectedRepositories, type AvailableRepository } from "../routes/settings/-hooks/repositoryFeatures";
+
+// Removes selected repositories that GitHub no longer lists — a repo that was
+// renamed (its old name still resolves via GitHub's redirect, so it would surface
+// duplicate items across the dashboard, PRs, and Attention) or one the user lost
+// access to. Runs once the live repo list has loaded *successfully*, so a
+// transient fetch failure can never wrongly drop a still-valid selection.
+export const useReconcileSelectedRepositories = () => {
+  const { data: available, isSuccess } = useRepositories();
+  const { data: selected } = useSelectedRepositories();
+  const { mutate: updateSelected } = useUpdateSelectedRepositories();
+
+  useEffect(() => {
+    if (!isSuccess || !available || !selected) return;
+
+    const availableRepos: AvailableRepository[] = available
+      .filter((r): r is typeof r & { owner: { login: string }; name: string } =>
+        !!r.owner?.login && !!r.name)
+      .map((r) => ({ owner: r.owner.login, name: r.name }));
+
+    const pruned = pruneSelectedRepositories(selected, availableRepos);
+    // Same reference back means nothing was stale — skip the write (and the
+    // dependent-query churn it would trigger). When something was pruned, writing
+    // updates localStorage and re-keys the dashboard/PR/Attention queries, so the
+    // stale repo's cached data drops out too.
+    if (pruned !== selected) updateSelected(pruned);
+  }, [isSuccess, available, selected, updateSelected]);
+};

--- a/src/Wrangler.App/src/routes/settings/-hooks/repositoryFeatures.test.ts
+++ b/src/Wrangler.App/src/routes/settings/-hooks/repositoryFeatures.test.ts
@@ -6,6 +6,7 @@ import {
   upsertRepository,
   isAttentionOptedIn,
   isAttentionItemVisible,
+  pruneSelectedRepositories,
   REPOSITORIES_KEY,
   PR_REPOSITORIES_KEY,
   SCHEMA_VERSION_KEY,
@@ -211,5 +212,39 @@ describe("isAttentionItemVisible", () => {
   it("hides items for unknown repos and unknown types", () => {
     expect(isAttentionItemVisible(item("WorkflowFailure", "missing"), repositories)).toBe(false);
     expect(isAttentionItemVisible(item("SomethingNew", "dash"), repositories)).toBe(false);
+  });
+});
+
+describe("pruneSelectedRepositories", () => {
+  const sel = (owner: string, name: string): SelectedRepository => ({ owner, name, workflows: [1], pullRequests: true, securityAlerts: true });
+
+  it("drops a selected repo no longer in the available list (the renamed-repo case)", () => {
+    // HomeAutomation was renamed to MooAir; GitHub only lists MooAir now.
+    const selected = [sel("AndrewMcLachlan", "HomeAutomation"), sel("AndrewMcLachlan", "MooAir")];
+    const available = [{ owner: "AndrewMcLachlan", name: "MooAir" }];
+
+    const result = pruneSelectedRepositories(selected, available);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("MooAir");
+  });
+
+  it("keeps every selected repo that is still available", () => {
+    const selected = [sel("acme", "widget"), sel("acme", "gadget")];
+    const available = [{ owner: "acme", name: "widget" }, { owner: "acme", name: "gadget" }, { owner: "acme", name: "other" }];
+
+    expect(pruneSelectedRepositories(selected, available)).toBe(selected); // same reference — nothing pruned
+  });
+
+  it("matches case-insensitively", () => {
+    const selected = [sel("Acme", "Widget")];
+    const available = [{ owner: "acme", name: "widget" }];
+
+    expect(pruneSelectedRepositories(selected, available)).toBe(selected);
+  });
+
+  it("prunes everything when the available list is empty", () => {
+    const selected = [sel("acme", "widget")];
+    expect(pruneSelectedRepositories(selected, [])).toHaveLength(0);
   });
 });

--- a/src/Wrangler.App/src/routes/settings/-hooks/repositoryFeatures.ts
+++ b/src/Wrangler.App/src/routes/settings/-hooks/repositoryFeatures.ts
@@ -26,6 +26,33 @@ export const hasDashboardWorkflows = (repo: SelectedRepository): boolean =>
 
 const repoKey = (owner: string, name: string) => `${owner}/${name}`;
 
+/** A repository as it currently exists in the user's GitHub account (owner + name). */
+export interface AvailableRepository {
+  owner: string;
+  name: string;
+}
+
+// Case-insensitive key for matching a selection against the live repo list —
+// GitHub treats owner/repo case-insensitively, and we don't want a case quirk to
+// wrongly prune a still-valid selection.
+const repoMatchKey = (owner: string, name: string) => `${owner}/${name}`.toLowerCase();
+
+/**
+ * Drops selected repositories that no longer appear in the user's current GitHub
+ * repo list — e.g. a repo that was renamed (GitHub keeps redirects, so the old
+ * name still resolves and would surface duplicate items) or one the user lost
+ * access to. Returns the SAME array reference when nothing changed, so callers
+ * can skip a needless storage write.
+ */
+export const pruneSelectedRepositories = (
+  selected: SelectedRepository[],
+  available: AvailableRepository[],
+): SelectedRepository[] => {
+  const availableKeys = new Set(available.map((r) => repoMatchKey(r.owner, r.name)));
+  const pruned = selected.filter((r) => availableKeys.has(repoMatchKey(r.owner, r.name)));
+  return pruned.length === selected.length ? selected : pruned;
+};
+
 const parseArray = <T>(json: string | null): T[] => {
   if (json === null) return [];
   try {


### PR DESCRIPTION
## Problem

A repository renamed on GitHub (e.g. `HomeAutomation` → `MooAir`) shows up **twice** — most visibly as two identical Attention items whose links both go to the same place.

**Root cause:** the client stores selected repos by `owner/name` with no stable id. After a rename, the old name (`HomeAutomation`) lingers in storage while the new name (`MooAir`) is also selected. GitHub's rename **redirect** resolves the old name to the same repo, so the backend produces items for both — same `HtmlUrl`/`WorkflowRunId`, differing only in the stale label. It's systemic (dashboard and PRs dupe too), not Attention-specific.

## Fix

Reconcile the selection against the live repo list (per your call — drop repos that no longer appear in your GitHub repo list):

- **`pruneSelectedRepositories(selected, available)`** (pure, in `repositoryFeatures.ts`) — drops any selected repo whose `owner/name` (case-insensitive) isn't in the current `getRepositories` result. Returns the same reference when nothing changed.
- **`useReconcileSelectedRepositories`** — applies it **only once the repo list has loaded successfully** (never on a transient fetch failure, so a valid selection is never wrongly dropped). Mounted app-wide in `App.tsx`. Writing the pruned list back to storage re-keys the dashboard/PR/Attention queries, so the stale repo's cached data drops out too.

This fixes the duplicate everywhere, not just the Attention feed.

## Testing

4 new unit tests for `pruneSelectedRepositories` (the renamed-repo case, keeps-still-available, case-insensitive matching, empty-available). Frontend **52/52**, lint 0 errors, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)