### PR TITLE
Use the new Bell icon for the attention nav item

### DIFF
--- a/src/Wrangler.App/package-lock.json
+++ b/src/Wrangler.App/package-lock.json
@@ -8,9 +8,9 @@
       "name": "wrangler",
       "version": "0.0.0",
       "dependencies": {
-        "@andrewmclachlan/moo-app": "^5.2.97",
-        "@andrewmclachlan/moo-ds": "^5.2.97",
-        "@andrewmclachlan/moo-icons": "^5.2.97",
+        "@andrewmclachlan/moo-app": "^5.2.197",
+        "@andrewmclachlan/moo-ds": "^5.2.197",
+        "@andrewmclachlan/moo-icons": "^5.2.197",
         "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-router": "^1.170.18",
         "@tanstack/react-router-devtools": "^1.167.0",
@@ -44,13 +44,13 @@
       }
     },
     "node_modules/@andrewmclachlan/moo-app": {
-      "version": "5.2.97",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.97/36ae1b5ead10ca5eaedfef573d6ef366c4fb2c33",
-      "integrity": "sha512-nvaQGk0N+tZJazW0DJS2rL6LhWOaIJDRO1qXQavYr1pWHf0Tm64Ds9tqa8DUASfTLzw2hc8Reau3OE1+GCksmQ==",
+      "version": "5.2.197",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-app/5.2.197/31b197aa5910882e5a2682f1d21f886abc3c8343",
+      "integrity": "sha512-ILBXcu0OKlYWwjPnMImsWJXJGyzHFLxGbz2ONmZ3J7PaHjJGsyVUGDuzy7vI14UKB7ri3z+T75rF3g1FSEAhow==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-browser": "^5.17.1",
-        "axios": "^1.18.1",
+        "@azure/msal-browser": "^5.17.3",
+        "axios": "^1.19.0",
         "classnames": "^2.5.1",
         "date-fns": "^4.4.0",
         "react-error-boundary": "^6.1.2",
@@ -59,23 +59,23 @@
       },
       "peerDependencies": {
         "@andrewmclachlan/moo-ds": ">=4.0.0",
-        "@azure/msal-react": "^5.5.3",
+        "@azure/msal-react": "^5.5.4",
         "@fortawesome/fontawesome-svg-core": "^7.3.1",
         "@fortawesome/free-regular-svg-icons": "^7.3.1",
         "@fortawesome/free-solid-svg-icons": "^7.3.1",
-        "@fortawesome/react-fontawesome": "^3.4.0",
-        "@tanstack/react-query": "^5.101.2",
+        "@fortawesome/react-fontawesome": "^3.5.0",
+        "@tanstack/react-query": "^5.101.4",
         "@tanstack/react-query-persist-client": "^5.101.2",
         "@tanstack/react-router": "^1.170.16",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
-        "react-hook-form": "^7.82.0"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-hook-form": "^7.83.0"
       }
     },
     "node_modules/@andrewmclachlan/moo-ds": {
-      "version": "5.2.97",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.97/a7ce9740788d03d81fa2a3234ce13388de0d87e6",
-      "integrity": "sha512-NUv8hG8Bij8Ziq4CJfFdfYCuAYZ20GFXj1j/yr3roN8hS8xt2RAN5RaWPYcrHwoJNAUD76fLWI7c0YZbHdKm1Q==",
+      "version": "5.2.197",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-ds/5.2.197/e3cdc50f8a166dd23a2e84949f15316a987f9231",
+      "integrity": "sha512-Rb5+z9lnp5scpNJ5BfJ3K2k5YoTodsan1TxXia9hEMGxQAJf3jScsvkbzHpBsavRvNGCVfiZXDKlvEAWmwVqZA==",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-table": "^8.21.0",
@@ -89,54 +89,54 @@
         "@fortawesome/fontawesome-svg-core": "^7.3.1",
         "@fortawesome/free-regular-svg-icons": "^7.3.1",
         "@fortawesome/free-solid-svg-icons": "^7.3.1",
-        "@fortawesome/react-fontawesome": "^3.4.0",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
-        "react-hook-form": "^7.82.0"
+        "@fortawesome/react-fontawesome": "^3.5.0",
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8",
+        "react-hook-form": "^7.83.0"
       }
     },
     "node_modules/@andrewmclachlan/moo-icons": {
-      "version": "5.2.97",
-      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.97/ea2de88fab6baaf6957685e5c3d1053330ee21d5",
-      "integrity": "sha512-0g6+eU8zUjETVBRx/IHHoWzDTBNMzIwg3grmSSg9SIpjlPEsdX17VcSo5GtSwRVKQr6EAtVw4WIIPrBv1Vpjmg==",
+      "version": "5.2.197",
+      "resolved": "https://npm.pkg.github.com/download/@andrewmclachlan/moo-icons/5.2.197/220d2e3fa8fb90ec7568d45e4678bb2379bf1e92",
+      "integrity": "sha512-XSqFeso7pZQbNZTM4Io+4xTMoW/ECJQn+QeQEy58eqOwx3pcVODFHFe+sUFm3QTSP5gG+G4q2eygrrJApGcAfw==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.17.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.1.tgz",
-      "integrity": "sha512-zBhRGzABKSI7hfWh5EaZmril5ybZ7imBN1qEZl5sDTaelr+l8SnPjZO50Q4dnKnm347YPIlBMSnXKZyh3Yu5DQ==",
+      "version": "5.17.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.17.3.tgz",
+      "integrity": "sha512-qMabD7Xrm/UgRhs+/IVyCTZRjUl8Qb+uGsRrCkaKNWsiTwRaeyStJbChE7/ySNTNYtiWo7khfF7vUDd0wGMnLw==",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.11.2"
+        "@azure/msal-common": "16.11.3"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.11.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.2.tgz",
-      "integrity": "sha512-yDhtBOGDCdK9ipQ9g3+wmlMEPnZx2pXaDicDd9jYyR1L+7lEbvEohTDmF5qejZDutZY3m9pWPxeYxzNC701A2w==",
+      "version": "16.11.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.3.tgz",
+      "integrity": "sha512-VeXOW+t3Rdd9XGX6lVyIg3DhtjMR1JD8ARKcsnGbJFUWwAmF3sHL7GwZc/ZjEUfHESResAonETRYCuG06OBT7A==",
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-react": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-5.5.3.tgz",
-      "integrity": "sha512-wPSCQuKFilQNSn/1M2FabKDanRc6Any9RTAXOp9uJGe6OYCEphetF9BTu68aIHsE+I2GFkXVqjx359VMRs+/jA==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/@azure/msal-react/-/msal-react-5.5.4.tgz",
+      "integrity": "sha512-/LbFigWLD0NUkWHr3ZZogvRGZNKlsiYDaHo2zLANU4u/7yO/TKDFunKx8M1m8fSRS0pXS5M6me7NEqDlOE8FyA==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20"
       },
       "peerDependencies": {
-        "@azure/msal-browser": "^5.17.1",
+        "@azure/msal-browser": "^5.17.3",
         "react": "^16.8.0 || ^17 || ^18 || ^19.2.1"
       }
     },
@@ -1203,9 +1203,9 @@
       }
     },
     "node_modules/@fortawesome/react-fontawesome": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.4.0.tgz",
-      "integrity": "sha512-EgY5CXzzm6WGnUB40j9qNajYmoJHC8TUV/rvpcmHUoPZmQyRlh8WuRaxaerjMq61NZAz0vS+MOoJaPbZWRDibw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.5.0.tgz",
+      "integrity": "sha512-63mlRr6fiBbJ0wjr1Cf6dsDGtP2lNvk9lnatKgxs/fIkhslsZT291hIUzJkuUkI9yr69ZvWnWfgb2qXm4QyVaA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -3271,13 +3271,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -5794,9 +5794,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.82.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.82.0.tgz",
-      "integrity": "sha512-Zw/uFZ2dO+02GHlBn7JFGn8kZJ7LdM33B/0BXOovzFay+CMhf94JMw5BVu+F1tVkUKjNvBuaE3fz5BJhga10Tg==",
+      "version": "7.84.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.84.0.tgz",
+      "integrity": "sha512-+hWvQP6GLco56mDwrbU4XnHix8t1z90ltZsDIrREl+jnQFQxYLX8oAzqe/Xn8nHpmoXTY5M6oEXrAhbP1qevNQ==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/src/Wrangler.App/package.json
+++ b/src/Wrangler.App/package.json
@@ -14,9 +14,9 @@
     "update-moo": "npm install @andrewmclachlan/moo-app@latest @andrewmclachlan/moo-ds@latest @andrewmclachlan/moo-icons@latest"
   },
   "dependencies": {
-    "@andrewmclachlan/moo-app": "^5.2.97",
-    "@andrewmclachlan/moo-ds": "^5.2.97",
-    "@andrewmclachlan/moo-icons": "^5.2.97",
+    "@andrewmclachlan/moo-app": "^5.2.197",
+    "@andrewmclachlan/moo-ds": "^5.2.197",
+    "@andrewmclachlan/moo-icons": "^5.2.197",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-router": "^1.170.18",
     "@tanstack/react-router-devtools": "^1.167.0",

--- a/src/Wrangler.App/src/layout/Layout.tsx
+++ b/src/Wrangler.App/src/layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { Icon } from "@andrewmclachlan/moo-ds";
-import { Cog, Dashboard, PullRequest, Stack, UserShield } from "@andrewmclachlan/moo-icons";
+import { Bell, Cog, Dashboard, PullRequest, UserShield } from "@andrewmclachlan/moo-icons";
 import { Link } from "@tanstack/react-router";
 import type { PropsWithChildren } from "react";
 import { UserMenu } from "./UserMenu";
@@ -26,7 +26,7 @@ export const Layout: React.FC<PropsWithChildren> = ({ children }) => {
             <ul>
               <li>
                 <Link to="/attention" title="Needs your attention" className="attention-link">
-                  <Icon icon={Stack} />
+                  <Icon icon={Bell} />
                   {attentionCount > 0 && <span className="attention-dot" />}
                 </Link>
               </li>


### PR DESCRIPTION
Swaps the attention nav item from the `Stack` icon to the new `Bell` icon so it reads as a notifications bell.

## Changes
- Bump `@andrewmclachlan/moo-app` / `moo-ds` / `moo-icons` to **5.2.197**, which adds the `Bell` icon.
- `Layout.tsx`: attention link now uses `<Icon icon={Bell} />` instead of `Stack`.

## Verification
- `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)