### PR TITLE
Stop refetching stream-backed data on every page switch

### DIFF
--- a/src/Wrangler.App/src/hooks/streamReconnect.test.ts
+++ b/src/Wrangler.App/src/hooks/streamReconnect.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { createReconnectTracker, STREAM_BACKED_QUERY_KEYS } from "./streamReconnect";
+
+describe("createReconnectTracker", () => {
+  it("does not resync on the initial connect", () => {
+    const tracker = createReconnectTracker();
+    expect(tracker.onOpen()).toBe(false);
+  });
+
+  it("resyncs on an open that follows a drop", () => {
+    const tracker = createReconnectTracker();
+    tracker.onOpen();
+    tracker.onError();
+
+    expect(tracker.onOpen()).toBe(true);
+  });
+
+  it("resyncs once per outage, not once per failed retry", () => {
+    const tracker = createReconnectTracker();
+    tracker.onOpen();
+    // EventSource fires onerror for every failed retry while the server is down;
+    // onopen only fires once the connection is actually re-established.
+    tracker.onError();
+    tracker.onError();
+    tracker.onError();
+
+    expect(tracker.onOpen()).toBe(true);
+  });
+
+  it("does not resync again on a subsequent open with no drop in between", () => {
+    const tracker = createReconnectTracker();
+    tracker.onError();
+    expect(tracker.onOpen()).toBe(true);
+    expect(tracker.onOpen()).toBe(false);
+  });
+
+  it("resyncs again on a second, separate outage", () => {
+    const tracker = createReconnectTracker();
+    tracker.onOpen();
+
+    tracker.onError();
+    expect(tracker.onOpen()).toBe(true);
+
+    tracker.onError();
+    expect(tracker.onOpen()).toBe(true);
+  });
+
+  it("tracks each stream independently", () => {
+    const first = createReconnectTracker();
+    const second = createReconnectTracker();
+    first.onError();
+
+    expect(second.onOpen()).toBe(false);
+    expect(first.onOpen()).toBe(true);
+  });
+});
+
+describe("STREAM_BACKED_QUERY_KEYS", () => {
+  it("covers exactly the caches the stream writes into", () => {
+    expect(STREAM_BACKED_QUERY_KEYS.map(([key]) => key)).toEqual([
+      "getWorkflows",
+      "getWorkflowRuns",
+      "pullRequests",
+    ]);
+  });
+});

--- a/src/Wrangler.App/src/hooks/streamReconnect.ts
+++ b/src/Wrangler.App/src/hooks/streamReconnect.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure support for recovering the SSE stream's cache gap on reconnect. No React
+ * and no EventSource access, so it is unit-testable in a node environment
+ * alongside the other pure stream helpers (mergeWorkflowRun, mergePullRequest).
+ */
+
+/**
+ * The query caches the stream writes into (see useGitHubEventStream). A missed
+ * event can only leave these stale, so they are the only ones worth resyncing on
+ * reconnect. Attention and Gates are not stream-backed and self-heal via their
+ * own refetchInterval, so refetching them here would spend GitHub quota for
+ * nothing.
+ */
+export const STREAM_BACKED_QUERY_KEYS: readonly (readonly string[])[] = [
+  ["getWorkflows"],
+  ["getWorkflowRuns"],
+  ["pullRequests"],
+];
+
+export interface ReconnectTracker {
+  /** Record that the connection dropped. EventSource then retries on its own. */
+  onError: () => void;
+  /** Returns true when this open follows a drop — i.e. a genuine reconnect. */
+  onOpen: () => boolean;
+}
+
+/**
+ * Tracks whether an EventSource open is the initial connect or a reconnect after
+ * a drop.
+ *
+ * The stream sends no `id:` field and the broadcaster keeps no buffer, so there
+ * is no Last-Event-ID replay: events delivered while the connection was down are
+ * lost permanently. The only recovery is to refetch, but refetching on *every*
+ * open would duplicate the fetch the queries just did on mount. Hence the
+ * distinction — the first open resyncs nothing, a reconnect resyncs.
+ *
+ * Failed retries only fire onError; onOpen fires solely on a successful
+ * connection, so an outage produces exactly one resync when it recovers rather
+ * than one per retry attempt.
+ */
+export const createReconnectTracker = (): ReconnectTracker => {
+  let sawDisconnect = false;
+
+  return {
+    onError: () => {
+      sawDisconnect = true;
+    },
+    onOpen: () => {
+      const resync = sawDisconnect;
+      sawDisconnect = false;
+      return resync;
+    },
+  };
+};

--- a/src/Wrangler.App/src/hooks/useGitHubEventStream.ts
+++ b/src/Wrangler.App/src/hooks/useGitHubEventStream.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { mergeWorkflowRun, branchMatch } from "./mergeWorkflowRun";
 import { mergePullRequest, removePullRequest, isSamePullRequest, type PushedPullRequest } from "./mergePullRequest";
+import { createReconnectTracker, STREAM_BACKED_QUERY_KEYS } from "./streamReconnect";
 import type { PullRequestModel, RepositoryModel, WorkflowRunModel } from "../api";
 
 interface GitHubEvent {
@@ -129,6 +130,21 @@ export const useGitHubEventStream = (enabled: boolean = true) => {
         case "check_suite":
           scheduleCheckStatusRefetch(parsed);
           break;
+      }
+    };
+
+    // The stream carries no `id:` field and the broadcaster keeps no buffer, so
+    // there is no Last-Event-ID replay: anything delivered while the connection
+    // was down is lost for good. EventSource reconnects silently, so without this
+    // the gap would leave the caches stale indefinitely — which is what makes the
+    // long staleTimes on the stream-backed queries safe.
+    const reconnect = createReconnectTracker();
+
+    source.onerror = () => reconnect.onError();
+    source.onopen = () => {
+      if (!reconnect.onOpen()) return;
+      for (const queryKey of STREAM_BACKED_QUERY_KEYS) {
+        queryClient.invalidateQueries({ queryKey });
       }
     };
 

--- a/src/Wrangler.App/src/main.tsx
+++ b/src/Wrangler.App/src/main.tsx
@@ -36,7 +36,20 @@ declare module "@tanstack/react-router" {
 
 console.log("config", client.getConfig());
 
-const queryClient = new QueryClient();
+// The SSE stream (useGitHubEventStream) pushes workflow and PR updates straight
+// into the caches, so react-query's staleTime: 0 default — which refetches on
+// every mount, and therefore every page switch — spends GitHub quota re-fetching
+// data the stream already keeps current. Defaults here rather than per-hook so a
+// new query can't silently inherit the aggressive behaviour; hooks still override
+// where their freshness contract differs.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 configureInterceptors();
 

--- a/src/Wrangler.App/src/routes/dashboard/-hooks/useWorkflows.ts
+++ b/src/Wrangler.App/src/routes/dashboard/-hooks/useWorkflows.ts
@@ -120,5 +120,12 @@ export const useWorkflows = () => {
     // Status filtering reshapes the fetched data without a refetch, so it is a
     // select rather than part of the query key.
     select: (data) => filterByStatus(data, statusFilter),
+    // Matches usePullRequests. Workflow runs are not cached server-side (only the
+    // workflow definitions are), so each fetch costs a GitHub call per selected
+    // workflow — and the stream pushes runs into this cache anyway. The interval
+    // is the backstop for repos whose webhooks were never wired up.
+    refetchInterval: 10 * 60 * 1000,
+    staleTime: 10 * 60 * 1000,
+    refetchOnWindowFocus: false,
   });
 }


### PR DESCRIPTION
Switching Dashboard → PRs → Dashboard re-fetched the whole dashboard every time, spending GitHub quota on data the SSE stream already keeps current.

## The problem

`useWorkflows` set no `staleTime`, so it inherited react-query's default of `0` — stale the instant it landed, and therefore refetched by the default `refetchOnMount` on **every** return to the Dashboard, plus every window focus. `main.tsx` was a bare `new QueryClient()`, so no global default rescued it.

That is precisely the query the stream pushes runs into (`handleWorkflowRun` writes `["getWorkflows"]`), so the push work was undone on the next navigation. It isn't cheap either: backend caching covers workflow *definitions* only (`GetWorkflowsAsync`, 30 min) — `GetLastRunsAsync` has no cache, so each mount costs one GitHub call per selected workflow.

The other four pages already set 5–10 min staleTimes and were unaffected.

## Changes

**Caching** — `useWorkflows` gets the same 10 min `staleTime`/`refetchInterval` and `refetchOnWindowFocus: false` as `usePullRequests`. `QueryClient` gets defaults (5 min, no focus refetch) so a new query can't silently inherit `staleTime: 0` again.

**Reconnect resync** — longer staleTimes are only safe with a way to recover missed events. The stream sends no `id:` field and `EventBroadcaster` keeps no buffer, so there's no `Last-Event-ID` replay: events delivered while the connection was down are lost permanently, and `EventSource` reconnects silently. New `streamReconnect.ts` invalidates the three stream-backed caches on an open that *follows a drop*, leaving the initial connect alone so it doesn't duplicate the fetch the queries just did. Failed retries only fire `onerror`, so an outage produces one resync on recovery rather than one per attempt.

Attention and Gates are deliberately not resynced — they aren't stream-backed and self-heal via their own `refetchInterval`.

## Notes

- `useRepositories`/`useGroupedRepositories` go from `staleTime: 0` to 5 min; both are backend-cached 30 min anyway.
- The Attention bell no longer refreshes on window focus, but `useAttention` is mounted in `Layout` on every page, so its 10 min interval keeps the count current.

## Verification

- `vitest` **63/63** (6 new, covering initial connect, reconnect, one-resync-per-outage, and independent trackers)
- `npm run lint` 0 errors — the two warnings in `useGitHubEventStream.ts` are pre-existing, shifted by the added lines
- `npm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)