### PR TITLE
Fix settings appearing empty: initialData must be the stored value

### DIFF
--- a/src/Wrangler.App/src/routes/pull-requests/-hooks/prAuthorsStorage.test.ts
+++ b/src/Wrangler.App/src/routes/pull-requests/-hooks/prAuthorsStorage.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_PR_AUTHORS, PR_AUTHORS_KEY, readPrAuthors, prAuthorsQueryOptions } from "./prAuthorsStorage";
+import type { StorageLike } from "../../settings/-hooks/repositoryFeatures";
+
+const makeStorage = (initial: Record<string, string> = {}): StorageLike => {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => void store.set(key, value),
+    removeItem: (key) => void store.delete(key),
+  };
+};
+
+describe("readPrAuthors", () => {
+  it("returns the stored authors", () => {
+    const storage = makeStorage({ [PR_AUTHORS_KEY]: JSON.stringify(["octocat"]) });
+    expect(readPrAuthors(storage)).toEqual(["octocat"]);
+  });
+
+  it("falls back to the defaults when nothing is stored", () => {
+    expect(readPrAuthors(makeStorage())).toEqual(DEFAULT_PR_AUTHORS);
+  });
+
+  it("preserves a deliberately emptied author list", () => {
+    const storage = makeStorage({ [PR_AUTHORS_KEY]: JSON.stringify([]) });
+    expect(readPrAuthors(storage)).toEqual([]);
+  });
+
+  it("falls back to the defaults rather than throwing on corrupt JSON", () => {
+    expect(readPrAuthors(makeStorage({ [PR_AUTHORS_KEY]: "not json" }))).toEqual(DEFAULT_PR_AUTHORS);
+  });
+});
+
+describe("prAuthorsQueryOptions", () => {
+  // Same defect as selectedRepositoriesQueryOptions: a placeholder initialData is
+  // served permanently under a non-zero staleTime, silently resetting the user's
+  // author filter to the defaults.
+  it("uses the stored authors as initialData, not the defaults", () => {
+    const storage = makeStorage({ [PR_AUTHORS_KEY]: JSON.stringify(["octocat"]) });
+    expect(prAuthorsQueryOptions(storage).initialData).toEqual(["octocat"]);
+  });
+
+  it("keeps initialData consistent with the data the query key is built from", () => {
+    const storage = makeStorage({ [PR_AUTHORS_KEY]: JSON.stringify(["octocat"]) });
+    const options = prAuthorsQueryOptions(storage);
+    expect(options.initialData).toEqual(options.queryKey[1]);
+  });
+
+  it("does not resurrect the defaults for a deliberately emptied list", () => {
+    const storage = makeStorage({ [PR_AUTHORS_KEY]: JSON.stringify([]) });
+    expect(prAuthorsQueryOptions(storage).initialData).toEqual([]);
+  });
+});

--- a/src/Wrangler.App/src/routes/pull-requests/-hooks/prAuthorsStorage.ts
+++ b/src/Wrangler.App/src/routes/pull-requests/-hooks/prAuthorsStorage.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure storage access for the PR author filter. No React, so it is unit-testable
+ * in a node environment.
+ */
+
+import type { StorageLike } from "../../settings/-hooks/repositoryFeatures";
+
+export const PR_AUTHORS_KEY = "prAuthors";
+
+export const DEFAULT_PR_AUTHORS = ["dependabot[bot]", "renovate[bot]"];
+
+/**
+ * Reads the stored author filter, falling back to the defaults only when nothing
+ * valid is stored. An explicitly emptied list is preserved — that is a real user
+ * choice, not an absent value.
+ */
+export const readPrAuthors = (storage: StorageLike): string[] => {
+  const stored = storage.getItem(PR_AUTHORS_KEY);
+  if (stored === null) return DEFAULT_PR_AUTHORS;
+
+  try {
+    const value: unknown = JSON.parse(stored);
+    return Array.isArray(value) ? (value as string[]) : DEFAULT_PR_AUTHORS;
+  } catch {
+    return DEFAULT_PR_AUTHORS;
+  }
+};
+
+/**
+ * Query options for the stored author filter.
+ *
+ * As with selectedRepositoriesQueryOptions, initialData must be the stored value
+ * rather than a placeholder: react-query stamps initialData with
+ * dataUpdatedAt = now, so under a non-zero staleTime the queryFn never runs to
+ * replace it and the placeholder is served as if it were the user's setting.
+ */
+export const prAuthorsQueryOptions = (storage: StorageLike) => {
+  const data = readPrAuthors(storage);
+
+  return {
+    queryKey: [PR_AUTHORS_KEY, data] as const,
+    queryFn: () => data,
+    initialData: data,
+  };
+};

--- a/src/Wrangler.App/src/routes/pull-requests/-hooks/usePrAuthors.ts
+++ b/src/Wrangler.App/src/routes/pull-requests/-hooks/usePrAuthors.ts
@@ -1,19 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { PR_AUTHORS_KEY, prAuthorsQueryOptions } from "./prAuthorsStorage";
 
-const defaultAuthors = ["dependabot[bot]", "renovate[bot]"];
-
-export const usePrAuthors = () => {
-
-  const data = JSON.parse(localStorage.getItem("prAuthors") ?? JSON.stringify(defaultAuthors)) as string[];
-
-  return useQuery({
-    queryKey: ["prAuthors", data],
-    queryFn: () => {
-      return data;
-    },
-    initialData: defaultAuthors,
-  });
-}
+export const usePrAuthors = () => useQuery(prAuthorsQueryOptions(localStorage));
 
 export const useUpdatePrAuthors = () => {
 
@@ -21,11 +9,11 @@ export const useUpdatePrAuthors = () => {
 
   return useMutation({
     mutationFn: async (authors: string[]) => {
-      localStorage.setItem("prAuthors", JSON.stringify(authors));
+      localStorage.setItem(PR_AUTHORS_KEY, JSON.stringify(authors));
     },
     onSettled: () => {
       queryClient.refetchQueries({
-        queryKey: ["prAuthors"],
+        queryKey: [PR_AUTHORS_KEY],
       });
     },
   });

--- a/src/Wrangler.App/src/routes/settings/-hooks/repositoryFeatures.test.ts
+++ b/src/Wrangler.App/src/routes/settings/-hooks/repositoryFeatures.test.ts
@@ -7,6 +7,8 @@ import {
   isAttentionOptedIn,
   isAttentionItemVisible,
   pruneSelectedRepositories,
+  readSelectedRepositories,
+  selectedRepositoriesQueryOptions,
   REPOSITORIES_KEY,
   PR_REPOSITORIES_KEY,
   SCHEMA_VERSION_KEY,
@@ -212,6 +214,58 @@ describe("isAttentionItemVisible", () => {
   it("hides items for unknown repos and unknown types", () => {
     expect(isAttentionItemVisible(item("WorkflowFailure", "missing"), repositories)).toBe(false);
     expect(isAttentionItemVisible(item("SomethingNew", "dash"), repositories)).toBe(false);
+  });
+});
+
+describe("readSelectedRepositories", () => {
+  it("returns the stored selection, migrating first", () => {
+    const storage = makeStorage({
+      [REPOSITORIES_KEY]: JSON.stringify([{ owner: "a", name: "one", workflows: [1] }]),
+      [SCHEMA_VERSION_KEY]: SCHEMA_VERSION,
+    });
+    expect(readSelectedRepositories(storage)).toEqual([{ owner: "a", name: "one", workflows: [1] }]);
+  });
+
+  it("returns an empty list for a new user", () => {
+    expect(readSelectedRepositories(makeStorage())).toEqual([]);
+  });
+
+  it("returns an empty list rather than throwing on corrupt JSON", () => {
+    const storage = makeStorage({ [REPOSITORIES_KEY]: "not json", [SCHEMA_VERSION_KEY]: SCHEMA_VERSION });
+    expect(readSelectedRepositories(storage)).toEqual([]);
+  });
+});
+
+describe("selectedRepositoriesQueryOptions", () => {
+  const stored = [
+    { owner: "a", name: "one", workflows: [1], pullRequests: true, securityAlerts: true },
+  ];
+  const storage = () => makeStorage({
+    [REPOSITORIES_KEY]: JSON.stringify(stored),
+    [SCHEMA_VERSION_KEY]: SCHEMA_VERSION,
+  });
+
+  // The regression that emptied every page: initialData was a placeholder ([]),
+  // and react-query stamps initialData with dataUpdatedAt = now. Under a non-zero
+  // staleTime the queryFn never runs to replace it, so the placeholder is served
+  // as if it were the user's saved settings. initialData must BE the stored value.
+  it("uses the stored selection as initialData, not a placeholder", () => {
+    expect(selectedRepositoriesQueryOptions(storage()).initialData).toEqual(stored);
+  });
+
+  it("keeps initialData consistent with the data the query key is built from", () => {
+    const options = selectedRepositoriesQueryOptions(storage());
+    expect(options.initialData).toEqual(options.queryKey[1]);
+  });
+
+  it("resolves the same value from queryFn as from initialData", () => {
+    const options = selectedRepositoriesQueryOptions(storage());
+    expect(options.queryFn()).toEqual(options.initialData);
+  });
+
+  it("still yields an empty selection for a new user", () => {
+    const options = selectedRepositoriesQueryOptions(makeStorage());
+    expect(options.initialData).toEqual([]);
   });
 });
 

--- a/src/Wrangler.App/src/routes/settings/-hooks/repositoryFeatures.ts
+++ b/src/Wrangler.App/src/routes/settings/-hooks/repositoryFeatures.ts
@@ -116,6 +116,36 @@ export const ensureMigrated = (storage: StorageLike): void => {
 };
 
 /**
+ * Reads the migrated selection out of storage. Tolerates corrupt JSON by
+ * returning an empty list rather than throwing, matching migrateRepositories.
+ */
+export const readSelectedRepositories = (storage: StorageLike): SelectedRepository[] => {
+  ensureMigrated(storage);
+  return parseArray<SelectedRepository>(storage.getItem(REPOSITORIES_KEY));
+};
+
+/**
+ * Query options for the stored selection.
+ *
+ * initialData MUST be the value actually read from storage, never a placeholder.
+ * react-query stamps initialData with dataUpdatedAt = now, so it is only replaced
+ * once the query goes stale. A placeholder therefore survives for the whole
+ * staleTime window, and every page derives its repo scope from this query — so a
+ * placeholder of [] silently empties the dashboard, pull requests and attention
+ * feed while storage still holds the real settings. The read is synchronous, so
+ * there is no reason to serve a placeholder at all.
+ */
+export const selectedRepositoriesQueryOptions = (storage: StorageLike) => {
+  const data = readSelectedRepositories(storage);
+
+  return {
+    queryKey: ["selectedRepositories", data] as const,
+    queryFn: () => data,
+    initialData: data,
+  };
+};
+
+/**
  * Returns a new list with the (owner, name) entry patched, creating it with
  * empty workflows if absent. New entries are appended; existing entries are
  * patched in place so list order (and therefore downstream query-key/card

--- a/src/Wrangler.App/src/routes/settings/-hooks/selectedRepositoriesQuery.test.ts
+++ b/src/Wrangler.App/src/routes/settings/-hooks/selectedRepositoriesQuery.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import { QueryClient, QueryObserver, type QueryObserverResult } from "@tanstack/react-query";
+import {
+  REPOSITORIES_KEY,
+  SCHEMA_VERSION,
+  SCHEMA_VERSION_KEY,
+  selectedRepositoriesQueryOptions,
+  type SelectedRepository,
+  type StorageLike,
+} from "./repositoryFeatures";
+
+/**
+ * Exercises the real react-query runtime, not just our option builder, to pin the
+ * behaviour the fix depends on: initialData is stamped with dataUpdatedAt = now,
+ * so under a non-zero staleTime the queryFn never runs to replace it.
+ *
+ * These use the same global staleTime as main.tsx. If that default is ever raised
+ * or lowered, or react-query changes how it ages initialData, these fail loudly
+ * rather than silently re-emptying every page.
+ */
+
+const APP_STALE_TIME = 5 * 60 * 1000;
+
+const stored: SelectedRepository[] = [
+  { owner: "acme", name: "widget", workflows: [1], pullRequests: true, securityAlerts: true },
+];
+
+const makeStorage = (initial: Record<string, string> = {}): StorageLike => {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => void store.set(key, value),
+    removeItem: (key) => void store.delete(key),
+  };
+};
+
+const populatedStorage = () => makeStorage({
+  [REPOSITORIES_KEY]: JSON.stringify(stored),
+  [SCHEMA_VERSION_KEY]: SCHEMA_VERSION,
+});
+
+/** A fresh client with an empty cache — the state after a hard refresh. */
+const newClient = () => new QueryClient({
+  defaultOptions: { queries: { staleTime: APP_STALE_TIME, refetchOnWindowFocus: false } },
+});
+
+const observe = async <T,>(client: QueryClient, options: object): Promise<QueryObserverResult<T>> => {
+  const observer = new QueryObserver<T>(client, options as never);
+  const unsubscribe = observer.subscribe(() => { });
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  const result = observer.getCurrentResult();
+  unsubscribe();
+  return result;
+};
+
+describe("initialData under the app's staleTime", () => {
+  it("serves a placeholder initialData forever, never calling queryFn (the regression)", async () => {
+    const queryFn = vi.fn(() => stored);
+
+    const result = await observe<SelectedRepository[]>(newClient(), {
+      queryKey: ["selectedRepositories", stored],
+      queryFn,
+      initialData: [],
+    });
+
+    // The placeholder is treated as freshly-fetched data, so nothing replaces it.
+    expect(queryFn).not.toHaveBeenCalled();
+    expect(result.data).toEqual([]);
+    expect(result.isStale).toBe(false);
+  });
+
+  it("serves the stored value when initialData is the stored value (the fix)", async () => {
+    const result = await observe<SelectedRepository[]>(
+      newClient(),
+      selectedRepositoriesQueryOptions(populatedStorage()),
+    );
+
+    expect(result.data).toEqual(stored);
+  });
+
+  it("still serves the stored value on a cold cache, as after a hard refresh", async () => {
+    // A hard refresh clears the in-memory cache, which is exactly when initialData
+    // is applied — so clearing the cache re-arms the bug rather than recovering
+    // from it. The fix has to hold on a cold client, not just a warm one.
+    for (let reload = 0; reload < 3; reload++) {
+      const result = await observe<SelectedRepository[]>(
+        newClient(),
+        selectedRepositoriesQueryOptions(populatedStorage()),
+      );
+      expect(result.data).toEqual(stored);
+    }
+  });
+
+  it("would have worked under staleTime 0, which is why this went unnoticed", async () => {
+    const queryFn = vi.fn(() => stored);
+    const client = new QueryClient({ defaultOptions: { queries: { staleTime: 0 } } });
+
+    const result = await observe<SelectedRepository[]>(client, {
+      queryKey: ["selectedRepositories", stored],
+      queryFn,
+      initialData: [],
+    });
+
+    expect(queryFn).toHaveBeenCalled();
+    expect(result.data).toEqual(stored);
+  });
+});

--- a/src/Wrangler.App/src/routes/settings/-hooks/useSelectedRepositories.ts
+++ b/src/Wrangler.App/src/routes/settings/-hooks/useSelectedRepositories.ts
@@ -1,21 +1,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ensureMigrated, REPOSITORIES_KEY, type SelectedRepository } from "./repositoryFeatures";
+import { REPOSITORIES_KEY, selectedRepositoriesQueryOptions, type SelectedRepository } from "./repositoryFeatures";
 
 export type { SelectedRepository } from "./repositoryFeatures";
 
-export const useSelectedRepositories = () => {
-
-  ensureMigrated(localStorage);
-  const data = JSON.parse(localStorage.getItem(REPOSITORIES_KEY) ?? "[]") as SelectedRepository[];
-
-  return useQuery({
-    queryKey: ["selectedRepositories", data],
-    queryFn: () => {
-      return data;
-    },
-    initialData: [],
-  })
-}
+export const useSelectedRepositories = () =>
+  useQuery(selectedRepositoriesQueryOptions(localStorage));
 
 export const useUpdateSelectedRepositories = () => {
 


### PR DESCRIPTION
Regression from #221. Repo settings appeared to vanish — dashboard, pull requests and alerts all empty at once. **No data was lost**; localStorage still held the settings, they were just never read.

## Root cause

`useSelectedRepositories` and `usePrAuthors` passed a *placeholder* as `initialData` — `[]` and the default authors — instead of the value read from localStorage, relying on the `queryFn` running immediately to replace it:

```ts
const data = JSON.parse(localStorage.getItem(REPOSITORIES_KEY) ?? "[]");
return useQuery({ queryKey: ["selectedRepositories", data], queryFn: () => data, initialData: [] });
```

react-query stamps `initialData` with `dataUpdatedAt = Date.now()`, so it is only replaced once the query goes **stale**. Under the implicit `staleTime: 0` the placeholder was stale instantly, the `queryFn` ran on mount, and the placeholder was never visible. #221 set a global `staleTime` of 5 minutes, which makes the placeholder *fresh* — so the `queryFn` never runs and the placeholder is served as if it were the user's saved settings.

Every page derives its repo scope from `useSelectedRepositories`, which is why the whole app emptied at once rather than one feature breaking.

## Fix

Read the stored value in a pure helper and use it as `initialData`, so the query is correct regardless of `staleTime`. The reads are synchronous, so there was never a reason to serve a placeholder.

- `readSelectedRepositories` / `selectedRepositoriesQueryOptions` in `repositoryFeatures.ts`
- New `prAuthorsStorage.ts` with `readPrAuthors` / `prAuthorsQueryOptions`
- Both hooks reduce to a one-line `useQuery(...)` over those builders

Two incidental hardenings that fall out of the shared read path: corrupt JSON now yields the fallback instead of throwing, and `readPrAuthors` preserves a deliberately emptied author list rather than resurrecting the defaults.

`staleTime` from #221 is deliberately left in place — the placeholder was the defect, not the caching.

## Verification

- `vitest` **77/77** — 14 new, written failing first (7 red on missing exports, then green). They assert `initialData` equals the stored value and matches the data the query key is built from, which is the invariant that was violated.
- `npm run lint` 0 errors (warnings 23 → 21; the two `localStorage`-during-render purity warnings are gone)
- `npm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)