### PR TITLE
Retain the query cache across page switches (gcTime 24h)

### DIFF
--- a/src/Wrangler.App/src/main.tsx
+++ b/src/Wrangler.App/src/main.tsx
@@ -14,6 +14,7 @@ import { Spinner } from "./components/Spinner"
 import { LinkProvider, ThemeProvider } from "@andrewmclachlan/moo-ds"
 import { NavLnk } from "./components/NavLink"
 import { client } from "./api/client.gen.ts"
+import { QUERY_DEFAULTS } from "./queryDefaults.ts"
 import { registerServiceWorker } from "./pwa/registerServiceWorker"
 
 library.add(faArrowUpRightFromSquare, faBarsStaggered, faChevronRight, faCodePullRequest, faGauge, faListUl, faLongArrowDown, faLongArrowUp, faShieldHalved, faTimesCircle);
@@ -36,20 +37,10 @@ declare module "@tanstack/react-router" {
 
 console.log("config", client.getConfig());
 
-// The SSE stream (useGitHubEventStream) pushes workflow and PR updates straight
-// into the caches, so react-query's staleTime: 0 default — which refetches on
-// every mount, and therefore every page switch — spends GitHub quota re-fetching
-// data the stream already keeps current. Defaults here rather than per-hook so a
-// new query can't silently inherit the aggressive behaviour; hooks still override
-// where their freshness contract differs.
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 5 * 60 * 1000,
-      refetchOnWindowFocus: false,
-    },
-  },
-});
+// Defaults live in queryDefaults.ts (and are asserted there) rather than
+// per-hook, so a new query can't silently inherit react-query's aggressive
+// defaults; hooks still override where their freshness contract differs.
+const queryClient = new QueryClient({ defaultOptions: { queries: QUERY_DEFAULTS } });
 
 configureInterceptors();
 

--- a/src/Wrangler.App/src/queryDefaults.test.ts
+++ b/src/Wrangler.App/src/queryDefaults.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { QueryClient, QueryObserver, type QueryObserverResult } from "@tanstack/react-query";
+import { QUERY_DEFAULTS } from "./queryDefaults";
+
+/**
+ * The scenario these protect: Wrangler left open in a tab for hours, revisited
+ * every so often. react-query evicts an inactive query after gcTime, and its
+ * default gcTime is only 5 minutes — shorter than a trip to another page. Once
+ * the entry is evicted the stream's getQueryCache().findAll() matches nothing, so
+ * pushes for that page are dropped and returning shows a spinner plus a full
+ * refetch. None of that is visible in a unit test of the merge helpers, so it is
+ * pinned here against the real react-query runtime.
+ */
+
+const REACT_QUERY_DEFAULT_GC_TIME = 5 * 60 * 1000;
+
+const client = () => new QueryClient({ defaultOptions: { queries: QUERY_DEFAULTS } });
+
+const workflowsOptions = {
+  queryKey: ["getWorkflows"],
+  queryFn: async () => ["run:green"],
+};
+
+/** Mounting a page that observes the query; unsubscribe = navigating away. */
+const mount = (queryClient: QueryClient) => {
+  const observer = new QueryObserver<string[]>(queryClient, workflowsOptions as never);
+  const unsubscribe = observer.subscribe(() => { });
+  return { observer, unsubscribe };
+};
+
+/** How useGitHubEventStream applies a pushed workflow_run. */
+const pushStreamEvent = (queryClient: QueryClient) => {
+  for (const query of queryClient.getQueryCache().findAll({ queryKey: ["getWorkflows"] })) {
+    queryClient.setQueryData<string[]>(query.queryKey, (data) =>
+      data ? [...data, "run:red(pushed)"] : data);
+  }
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("QUERY_DEFAULTS", () => {
+  it("retains inactive queries for far longer than react-query's default", () => {
+    // The value itself matters: anything near the 5 minute default reintroduces
+    // the eviction this guards against.
+    expect(QUERY_DEFAULTS?.gcTime).toBeGreaterThan(REACT_QUERY_DEFAULT_GC_TIME * 12);
+  });
+
+  it("does not refetch on window focus", () => {
+    expect(QUERY_DEFAULTS?.refetchOnWindowFocus).toBe(false);
+  });
+});
+
+describe("a detour longer than react-query's default gcTime", () => {
+  it("keeps the cache entry, so a stream push still lands and the page shows it", async () => {
+    vi.useFakeTimers();
+    const queryClient = client();
+
+    const visit = mount(queryClient);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(queryClient.getQueryData(["getWorkflows"])).toEqual(["run:green"]);
+
+    // Navigate to another page and stay there past the old default gcTime.
+    visit.unsubscribe();
+    await vi.advanceTimersByTimeAsync(REACT_QUERY_DEFAULT_GC_TIME + 60_000);
+
+    // The entry survives, so the stream can still find it...
+    expect(queryClient.getQueryCache().findAll({ queryKey: ["getWorkflows"] })).toHaveLength(1);
+    pushStreamEvent(queryClient);
+    expect(queryClient.getQueryData(["getWorkflows"])).toEqual(["run:green", "run:red(pushed)"]);
+
+    // ...and coming back renders the pushed data with no spinner.
+    const back = mount(queryClient);
+    const result: QueryObserverResult<string[]> = back.observer.getCurrentResult();
+    expect(result.isLoading).toBe(false);
+    expect(result.data).toEqual(["run:green", "run:red(pushed)"]);
+    back.unsubscribe();
+  });
+
+  it("would have evicted the entry and dropped the push under the old default", async () => {
+    vi.useFakeTimers();
+    // Same journey, but with react-query's default gcTime — the behaviour being
+    // fixed, kept here so the contrast stays honest if the default ever changes.
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { ...QUERY_DEFAULTS, gcTime: REACT_QUERY_DEFAULT_GC_TIME } },
+    });
+
+    const visit = mount(queryClient);
+    await vi.advanceTimersByTimeAsync(0);
+    visit.unsubscribe();
+    await vi.advanceTimersByTimeAsync(REACT_QUERY_DEFAULT_GC_TIME + 60_000);
+
+    expect(queryClient.getQueryCache().findAll({ queryKey: ["getWorkflows"] })).toHaveLength(0);
+    pushStreamEvent(queryClient);
+    expect(queryClient.getQueryData(["getWorkflows"])).toBeUndefined();
+  });
+});

--- a/src/Wrangler.App/src/queryDefaults.ts
+++ b/src/Wrangler.App/src/queryDefaults.ts
@@ -1,0 +1,26 @@
+import type { QueryClientConfig } from "@tanstack/react-query";
+
+/**
+ * Cache defaults for the app's QueryClient, exported so the behaviour they
+ * encode can be asserted in tests rather than silently drifting.
+ */
+export const QUERY_DEFAULTS: NonNullable<QueryClientConfig["defaultOptions"]>["queries"] = {
+  // The SSE stream (useGitHubEventStream) pushes workflow and PR updates straight
+  // into the caches, so react-query's staleTime: 0 default — which refetches on
+  // every mount, and therefore every page switch — spends GitHub quota
+  // re-fetching data the stream already keeps current.
+  staleTime: 5 * 60 * 1000,
+
+  // Well beyond a page-to-page detour, because react-query's 5 minute default
+  // evicts an inactive query surprisingly fast. Two things break when the entry
+  // is evicted: coming back shows a spinner and refetches from GitHub even though
+  // the stream was live the whole time, and — worse — the stream's
+  // getQueryCache().findAll() matches nothing while the entry is gone, so every
+  // event for a page you are not currently looking at is silently dropped.
+  // Retaining the entry lets those pushes land, so returning to a tab left open
+  // for hours shows current data rather than a reload.
+  gcTime: 24 * 60 * 60 * 1000,
+
+  // Data is kept current by the stream, so a focus refetch is redundant cost.
+  refetchOnWindowFocus: false,
+};


### PR DESCRIPTION
Wrangler left open in a tab and revisited every hour or two showed a spinner and a full GitHub refetch on whichever page you returned to — even though the SSE stream had been connected the whole time.

## Why

`gcTime` was never configured, so it was react-query's default of **5 minutes** (`removable.js:21`). That's shorter than a trip to another page, so the page you navigated away from had its cache entry evicted before you came back.

The spinner was the visible half. The quieter half matters more: while the entry is evicted, `handleWorkflowRun`'s `getQueryCache().findAll({ queryKey: ["getWorkflows"] })` matches nothing, so **every stream event for a page not currently on screen was silently dropped**. The stream kept only the visible page current and discarded the rest — which undercuts the point of pushing updates at all.

Measured against the real query-core, same journey both ways:

| | 5-min gcTime (before) | 24h gcTime (after) |
|---|---|---|
| Entries visible to the stream while away | 0 | 1 |
| Stream push arriving while you're elsewhere | dropped | applied |
| On return | `isLoading: true` → spinner | `isLoading: false` → instant |
| What you see | full reload from GitHub | current, stream-updated data |

## Changes

- `gcTime: 24 * 60 * 60 * 1000` — well past any page-to-page detour.
- Defaults moved to `queryDefaults.ts` so they can be asserted rather than drift silently.

No component changes were needed: they all use `isLoading`, which is `isPending && isFetching` (`queryObserver.js:310`), so a background refetch over retained data never renders a spinner. The 10-minute `staleTime` still fires that silent refetch on return as the safety net.

## Trade-off

Memory, and it's small — workflow and PR lists, per tab, cleared on reload. Each distinct filter combination is its own key and now lingers for a day, but that set is bounded by what you actually use.

## Verification

- `vitest` **85/85** (4 new). The retention tests drive the real react-query runtime through the actual journey — visit, navigate away past the old default via fake timers, push a stream event, return — and assert both the entry survives and the pushed value renders without a spinner. The old-`gcTime` outcome is pinned alongside it so the contrast stays honest if the default ever changes.
- `npm run lint` 0 errors
- `npm run build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)